### PR TITLE
Fix invalid PodSpec by removing name field

### DIFF
--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -33,7 +33,6 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | trimSuffix "\n" | indent 8 }}
       {{- end }}
-      name: {{ include "gremlin.name"  . }}
       hostPID: {{ .Values.gremlin.hostPID }}
       hostNetwork: {{ .Values.gremlin.hostNetwork }}
       containers:


### PR DESCRIPTION
Deploying this chart caused this error:

unknown field "name" in io.k8s.api.core.v1.PodSpec

Removing the name field fixes this.