### PR TITLE
Add support for a Helm managed Secret

### DIFF
--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -56,7 +56,6 @@ helm install --name my-gremlin gremlin/gremlin
 
 ```shell
 helm repo add gremlin https://helm.gremlin.com
-helm install gremlin/gremlin --set gremlin.teamID=YOUR-TEAM-ID
 helm install --name my-gremlin gremlin/gremlin --set gremlin.client.certCreateSecret=true --set-file gremlin.client.certContent=gremlin.cert --set-file gremlin.client.keyContent=gremlin.key
 ```
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-* Kubernetes with extensions/v1beta1 available
+* Kubernetes with apps/v1 available
 
 ## Configuration
 
@@ -26,6 +26,9 @@ their default values. See values.yaml for all available options.
 | `gremlin.client.secretName`            | Kubernetes secret containing credentials                       | `gremlin-team-cert`                                                         |
 | `gremlin.client.cert`                  | Path to the client cert or the cert material base64 encoded    | `file:///var/lib/gremlin/cert/gremlin.cert`                                 |
 | `gremlin.client.key`                   | Path to the client key or the key material base64 encoded      | `file:///var/lib/gremlin/cert/gremlin.key`                                  |
+| `gremlin.client.certCreateSecret`                   | Instruct Helm to create a Secret for storing certs/keys      | `false`                                  |
+| `gremlin.client.certContent`                   | ASCII armored client cert material      | `""`                                  |
+| `gremlin.client.keyContent`                   | ASCII armored client key material      | `""`                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.
@@ -34,7 +37,9 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 
 If you don't already have them available, download you team certificates from the Gremlin app. To do so, go to [Company Settings](https://app.gremlin.com/settings/teams), and select your team. Click on the button labelled `Download` next to `Certificates`. If you don't see a button labelled `Download`, click on `Create New` to generate a new certificate.
 
-When you unzip the downloaded file, you will see two files named `TEAM_NAME-client.priv_key.pem` and `TEAM_NAME-client.pub_cert.pem`. Rename these to `gremlin.key` and `gremlin.cert` respectively, then create a kubernetes secret as follows:
+When you unzip the downloaded file, you will see two files named `TEAM_NAME-client.priv_key.pem` and `TEAM_NAME-client.pub_cert.pem`. Rename these to `gremlin.key` and `gremlin.cert` respectively.
+
+### Deploying with a manually created Kubernetes Secret
 
 ```shell
 kubectl create secret generic gremlin-team-cert --from-file=./gremlin.cert --from-file=./gremlin.key
@@ -45,6 +50,14 @@ Once your secret is created, install this chart with Helm:
 ```shell
 helm repo add gremlin https://helm.gremlin.com
 helm install --name my-gremlin gremlin/gremlin
+```
+
+### Deploying with a Helm created Kubernetes Secret
+
+```shell
+helm repo add gremlin https://helm.gremlin.com
+helm install gremlin/gremlin --set gremlin.teamID=YOUR-TEAM-ID
+helm install --name my-gremlin gremlin/gremlin --set gremlin.client.certCreateSecret=true --set-file gremlin.client.certContent=gremlin.cert --set-file gremlin.client.keyContent=gremlin.key
 ```
 
 ## Uninstall

--- a/gremlin/templates/secret.yaml
+++ b/gremlin/templates/secret.yaml
@@ -12,6 +12,6 @@ metadata:
     version: v1
 type: kubernetes.io/Opaque
 data:
-  gremlin.cert: {{ .Values.gremlin.client.certContent | toString | b64enc }}
-  gremlin.key: {{ .Values.gremlin.client.keyContent | toString | b64enc }}
+  gremlin.cert: {{ required "A valid .Values.gremlin.client.certContent entry required!" .Values.gremlin.client.certContent | toString | b64enc }}
+  gremlin.key: {{ required "A valid .Values.gremlin.client.keyContent entry required!" .Values.gremlin.client.keyContent | toString | b64enc }}
 {{- end }}

--- a/gremlin/templates/secret.yaml
+++ b/gremlin/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.gremlin.client.certCreateSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.gremlin.client.secretName }}
+  labels:
+    app.kubernetes.io/name: {{ include "gremlin.name" . }}
+    helm.sh/chart: {{ include "gremlin.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    version: v1
+type: kubernetes.io/Opaque
+data:
+  gremlin.cert: {{ .Values.gremlin.client.certContent | toString | b64enc }}
+  gremlin.key: {{ .Values.gremlin.client.keyContent | toString | b64enc }}
+{{- end }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -24,3 +24,9 @@ gremlin:
     secretName: gremlin-team-cert
     cert: file:///var/lib/gremlin/cert/gremlin.cert
     key: file:///var/lib/gremlin/cert/gremlin.key
+
+    # # Uncomment and fill this block to have Helm create the secret
+    # # populated with your Gremlin key and cert
+    # certCreateSecret: true
+    # certContent: ""
+    # keyContent: ""


### PR DESCRIPTION
# Problem

The Helm chart currently relies on a manually created Kubernetes Secret to store the client key and cert files.  In some cases it can be easier to supply Helm with the relevant key materials and allow it to create the Secret.

# Solution

This PR maintains the previous default functionality where a manually created Secret is expected.  However, there is a new option where Helm can be provided with `certContent` and `keyContent` so it can create the Secret for you.

# QA

## Ensuring the previous functionality remains

Template out the chart with the default values.yaml
```
helm template gremlin/
```
Ensure things look as expected.

## Verify new Secrets functionality

Put a gremlin key and cert in the local directory.  Template out the chart with the new options set and ensure they look as expected.

```
helm template gremlin/ --set gremlin.client.certCreateSecret=true --set-file gremlin.client.certContent=gremlin.crt --set-file gremlin.client.keyContent=gremlin.key
```