### PR TITLE
Allow overriding the name of the Gremlin image deployed

### DIFF
--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -59,6 +59,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: GREMLIN_DOCKER_IMAGE
+            value: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         volumeMounts:
           - name: docker-sock
             mountPath: /var/run/docker.sock


### PR DESCRIPTION
Customers using an internal repository, and therefore need to override the name of the docker image. While this is possible to do with our helm chart at the base level, the override does not persist for the sidecar containers we spin up, unless the envar `GREMLIN_DOCKER_IMAGE` is exposed to the daemon container. This adds the `GREMLIN_DOCKER_IMAGE` envar to the daemonset template, pulling from the same data as the base image name.