### PR TITLE
AGENT-100: Add apparmor profile to DaemonSet config

### DIFF
--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "gremlin.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create an apparmor profile from the following order of operations:
+1. if `apparmorOverride` has been supplied, use that
+2. if `apparmorOverride` is not supplied, and `hostPID` has been supplied and is `true`: use `unconfined`
+3. None of the above is supplied: use `runtime/default`
+*/}}
+{{- define "gremlin.apparmor" -}}
+{{- if .Values.apparmorOverride -}}
+{{- .Values.apparmorOverride -}}
+{{- else if .values.hostPID -}}
+{{- "unconfined" }}
+{{- else }}
+{{- "runtime/default" }}
+{{- end -}}
+{{- end -}}

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -40,7 +40,7 @@ Create an apparmor profile from the following order of operations:
 {{- define "gremlin.apparmor" -}}
 {{- if .Values.apparmorOverride -}}
 {{- .Values.apparmorOverride -}}
-{{- else if .values.hostPID -}}
+{{- else if .Values.gremlin.hostPID -}}
 {{- "unconfined" }}
 {{- else }}
 {{- "runtime/default" }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         version: v1
+      annotations:
+        # Tell the Gremlin Daemon containers to launch in the unconfined
+        container.apparmor.security.beta.kubernetes.io/{{ include "gremlin.fullname" . }}: {{ include "gremlin.apparmor" }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         version: v1
       annotations:
         # Tell the Gremlin Daemon containers to launch in the unconfined
-        container.apparmor.security.beta.kubernetes.io/{{ include "gremlin.fullname" . }}: {{ include "gremlin.apparmor" }}
+        container.apparmor.security.beta.kubernetes.io/{{ include "gremlin.fullname" . }}: {{ include "gremlin.apparmor" . }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -9,6 +9,7 @@ image:
 
 nameOverride: ""
 fullnameOverride: ""
+apparmorOverride: ""
 
 nodeSelector: {}
 


### PR DESCRIPTION
Add [apparmor
profile](https://kubernetes.io/docs/tutorials/clusters/apparmor/) to the
Gremlin DaemonSet. The behavior of this apparmore profile is as follows:

1. Use the profile specified by `apparmorOverride` if present
2. Otherwise, use `apparmor: runtime/default` if `gremlin.hostPID
== false`, or `unconfined` if `gremlin.hostPID == true`