### PR TITLE
Use .Chart.Name for apparmor

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.1.4
+version: 0.1.5
 description: The Gremlin Inc client application
 appVersion: "2.12.15"
 apiVersion: v1

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         version: v1
       annotations:
         # Tell the Gremlin Daemon containers to launch in the unconfined
-        container.apparmor.security.beta.kubernetes.io/{{ include "gremlin.fullname" . }}: {{ include "gremlin.apparmor" . }}
+        container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: {{ include "gremlin.apparmor" . }}
     spec:
       {{- if .Values.affinity }}
       affinity:


### PR DESCRIPTION
This was using `gremlin.fullname` helper value, which works as long as the full name is overridden such that the container name matches but fails otherwise.