### PR TITLE
AGENT-183: Use gremlin.apparmor only when supplied by user input

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.1.5
+version: 0.1.6
 description: The Gremlin Inc client application
 appVersion: "2.12.15"
 apiVersion: v1

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,6 +20,7 @@ their default values. See values.yaml for all available options.
 | `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |
+| `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.teamID`                       | Gremlin Team ID to authenticate with                           | `""`                                                                        |
 | `gremlin.hostPID`                      | Enable host-level process killing                              | `false`                                                                     |
 | `gremlin.hostNetwork`                  | Enable host-level network attacks                              | `false`                                                                     |

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -30,19 +30,3 @@ Create chart name and version as used by the chart label.
 {{- define "gremlin.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Create an apparmor profile from the following order of operations:
-1. if `apparmorOverride` has been supplied, use that
-2. if `apparmorOverride` is not supplied, and `hostPID` has been supplied and is `true`: use `unconfined`
-3. None of the above is supplied: use `runtime/default`
-*/}}
-{{- define "gremlin.apparmor" -}}
-{{- if .Values.apparmorOverride -}}
-{{- .Values.apparmorOverride -}}
-{{- else if .Values.gremlin.hostPID -}}
-{{- "unconfined" }}
-{{- else }}
-{{- "runtime/default" }}
-{{- end -}}
-{{- end -}}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -20,9 +20,11 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         version: v1
+      {{- if .Values.gremlin.apparmor }}
       annotations:
         # Tell the Gremlin Daemon containers to launch in the unconfined
         container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: {{ include "gremlin.apparmor" . }}
+      {{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       {{- if .Values.gremlin.apparmor }}
       annotations:
         # Tell the Gremlin Daemon containers to launch in the unconfined
-        container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: {{ include "gremlin.apparmor" . }}
+        container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: {{ .Values.gremlin.apparmor }}
       {{- end }}
     spec:
       {{- if .Values.affinity }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -9,7 +9,6 @@ image:
 
 nameOverride: ""
 fullnameOverride: ""
-apparmorOverride: ""
 
 nodeSelector: {}
 
@@ -18,6 +17,7 @@ tolerations: []
 affinity: {}
 
 gremlin:
+  apparmor: ""
   teamID: ""
   hostPID: false
   hostNetwork: false


### PR DESCRIPTION
A recent change broke the Gremlin Helm Chart for systems that did not
have apparmor. This change modify's this chart's behavior such that the
new apparmor annotation is applied only when the user supplies `--set
gremlin.apparmor=...`.

While this means we don't set apparmor to the exact profile Gremlin
desires, we allow it to be configurable enough to work for systems with
and without apparmor.

In a later change, I propose we do the same for SELinux, and
automatically set proper values based on some discovery of what the
system supports. We'll start with user input first.