### PR TITLE
Install kubernetes client by default

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.1.6
+version: 0.1.7
 description: The Gremlin Inc client application
 appVersion: "2.12.15"
 apiVersion: v1

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -27,11 +27,11 @@ their default values. See values.yaml for all available options.
 | `gremlin.client.secretName`            | Kubernetes secret containing credentials                       | `gremlin-team-cert`                                                         |
 | `gremlin.client.cert`                  | Path to the client cert or the cert material base64 encoded    | `file:///var/lib/gremlin/cert/gremlin.cert`                                 |
 | `gremlin.client.key`                   | Path to the client key or the key material base64 encoded      | `file:///var/lib/gremlin/cert/gremlin.key`                                  |
-| `gremlin.client.certCreateSecret`                   | Instruct Helm to create a Secret for storing certs/keys      | `false`                                  |
-| `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`
-| `gremlin.client.certContent`                   | ASCII armored client cert material      | `""`                                  |
-| `gremlin.client.keyContent`                   | ASCII armored client key material      | `""`                                  |
-
+| `gremlin.client.certCreateSecret`      | Instruct Helm to create a Secret for storing certs/keys        | `false`                                                                     |
+| `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`                                                                        |
+| `gremlin.client.certContent`           | ASCII armored client cert material                             | `""`                                                                        |
+| `gremlin.client.keyContent`            | ASCII armored client key material                              | `""`                                                                        |
+| `gremlin.installK8sClient`             | Enable kubernetes targeting by installing k8s client           |  true                                                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -1,0 +1,49 @@
+{{ if .Values.gremlin.installK8sClient }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: chao
+    app.kubernetes.io/name: chao
+    app.kubernetes.io/version: "1"
+  name: chao
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: chao
+      app.kubernetes.io/name: chao
+      app.kubernetes.io/version: "1"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: chao
+        app.kubernetes.io/name: chao
+        app.kubernetes.io/version: "1"
+    spec:
+      serviceAccountName: chao
+      containers:
+        - image: gremlin/chao:latest
+          args:
+          - "-team_id"
+          - {{ .Values.gremlin.teamID }}
+          - "-cluster_id"
+          - {{ .Values.gremlin.clusterID }}
+          - "-cert_path"
+          - "/var/lib/gremlin/cert/gremlin.cert"
+          - "-key_path"
+          - "/var/lib/gremlin/cert/gremlin.key"
+          imagePullPolicy: Always
+          name: chao
+          volumeMounts:
+          - name: gremlin-cert
+            mountPath: /var/lib/gremlin/cert
+            readOnly: true
+      volumes:
+      - name: gremlin-cert
+        secret:
+          secretName: gremlin-team-cert
+---
+{{ end }}
+

--- a/gremlin/templates/chao-service-account.yaml
+++ b/gremlin/templates/chao-service-account.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.gremlin.installK8sClient }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chao
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gremlin-watcher
+rules:
+  - apiGroups: ["apps"]
+    resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chao
+subjects:
+  - kind: ServiceAccount
+    name: chao
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gremlin-watcher
+---
+{{ end }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "gremlin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "gremlin.name" . }}
     helm.sh/chart: {{ include "gremlin.chart" . }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -21,6 +21,7 @@ gremlin:
   teamID: ""
   hostPID: false
   hostNetwork: false
+  installK8sClient: true
   client:
     secretName: gremlin-team-cert
     cert: file:///var/lib/gremlin/cert/gremlin.cert


### PR DESCRIPTION
Add a deployment and supporting resources for managing a gremlin
kubernetes client. The client is installed by default but may be
disabled by setting `gremlin.installK8sClient=false`