### PR TITLE
Refactor gremlin values to support cert+secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Add this Chart repo to Helm, and install:
 
 ```console
 helm repo add gremlin https://helm.gremlin.com/
-helm install gremlin/gremlin --set gremlin.teamID=YOUR-TEAM-ID
+helm install gremlin/gremlin \
+    --name gremlin \
+    --namespace gremlin \
+    --set gremlin.secret.managed=true \
+    --set gremlin.secret.type=secret \
+    --set gremlin.secret.teamID=YOUR-TEAM-ID \
+    --set gremlin.secret.clusterID=YOUR-CLUSTER-ID \
+    --set gremlin.secret.teamSecret=YOUR-TEAM-SECRET
 ```
 
 For more detailed instructions, see the chart's documentation [here](https://github.com/gremlin/helm/blob/master/gremlin/README.md).

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -21,27 +21,36 @@ their default values. See values.yaml for all available options.
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
-| `gremlin.teamID`                       | Gremlin Team ID to authenticate with                           | `""`                                                                        |
-| `gremlin.clusterID`                   | Arbitrary string that uniquely identifies your cluster (e.g. `my-production-cluster`) | `""`                                                                        |
+| `gremlin.secret.managed`               | Specifies whether Gremlin should manage its secrets with Helm  | `false`                                                                     |
+| `gremlin.secret.type`                  | The type of certificate to use, can be either `certificate` or `secret` | `certificate`                                                      |
+| `gremlin.secret.name`                  | The name of certificate to use, like in the case of pointing to an eternally managed secret | `gremlin-team-cert`                            |
+| `gremlin.secret.teamID`                | Gremlin Team ID to authenticate with                           | `""`                                                                        |
+| `gremlin.secret.clusterID`             | Arbitrary string that uniquely identifies your cluster (e.g. `my-production-cluster`) | `""`                                                 |
+| `gremlin.secret.certificate`           | Contents of the certificate. Required if using managed secrets of `type=certificate`  | `""`                                                 |
+| `gremlin.secret.key`                   | Contents of the private key. Required if using managed secrets of `type=certificate`  | `""`                                                 |
+| `gremlin.secret.teamSecret`            | Gremlin's team secret. Required if using managed secrets of `type=secret`  | `""`                                                            |
 | `gremlin.hostPID`                      | Enable host-level process killing                              | `false`                                                                     |
 | `gremlin.hostNetwork`                  | Enable host-level network attacks                              | `false`                                                                     |
-| `gremlin.client.secretName`            | Kubernetes secret containing credentials                       | `gremlin-team-cert`                                                         |
-| `gremlin.client.cert`                  | Path to the client cert or the cert material base64 encoded    | `file:///var/lib/gremlin/cert/gremlin.cert`                                 |
-| `gremlin.client.key`                   | Path to the client key or the key material base64 encoded      | `file:///var/lib/gremlin/cert/gremlin.key`                                  |
-| `gremlin.client.certCreateSecret`      | Instruct Helm to create a Secret for storing certs/keys        | `false`                                                                     |
 | `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`                                                                        |
-| `gremlin.client.certContent`           | ASCII armored client cert material                             | `""`                                                                        |
-| `gremlin.client.keyContent`            | ASCII armored client key material                              | `""`                                                                        |
 | `gremlin.installK8sClient`             | Enable kubernetes targeting by installing k8s client           |  true                                                                       |
 
-Specify each parameter using the `--set key=value[,key=value]` argument to
-`helm install`.
+Specify each parameter using the `--set[-file] key=value[,key=value]` argument to `helm install`.
 
 ## Installation
 
-If you don't already have them available, download you team certificates from the Gremlin app. To do so, go to [Company Settings](https://app.gremlin.com/settings/teams), and select your team. Click on the button labelled `Download` next to `Certificates`. If you don't see a button labelled `Download`, click on `Create New` to generate a new certificate.
+All Gremlin installations require authentication with our Gremlin control plane. There are two types of authentication available to Gremlin and Helm: `certificate`, and `secret`. You can find out more about these authentication types here.
 
-When you unzip the downloaded file, you will see two files named `TEAM_NAME-client.priv_key.pem` and `TEAM_NAME-client.pub_cert.pem`. Rename these to `gremlin.key` and `gremlin.cert` respectively.
+For this Helm chart, you'll need to download your team certificate or team secret from the Gremlin app.
+
+**Certificate**
+1. go to [Company Settings](https://app.gremlin.com/settings/teams), and select your team, and then `Configuration`
+2. Click on the button labeled `Download` next to `Certificates` (If you don't see a button labelled `Download`, click on `Create New` to generate a new certificate)
+3. When you unzip the downloaded file, you will see two files named `TEAM_NAME-client.priv_key.pem` and `TEAM_NAME-client.pub_cert.pem`. Rename these to `gremlin.key` and `gremlin.cert` respectively. These will be refered to as `/path/to/gremlin.cert` and `/path/to/gremlin.key` in later instructions.
+
+**Secret**
+1. go to [Company Settings](https://app.gremlin.com/settings/teams), and select your team, and then `Configuration`
+2. Click on the button labeled `New` next to `Secret Key` (If you don't see a button labeled `New`, it's already been created. Talk to your administrator who should have the key or click the `Reset` button to create a new one)
+3. You should see a value named `GREMLIN_TEAM_SECRET`, this will be refered to as `$GREMLIN_TEAM_SECRET` in later instructions
 
 ### With Managed Secrets
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -38,7 +38,7 @@ Specify each parameter using the `--set[-file] key=value[,key=value]` argument t
 
 ## Installation
 
-All Gremlin installations require authentication with our Gremlin control plane. There are two types of authentication available to Gremlin and Helm: `certificate`, and `secret`. You can find out more about these authentication types here.
+All Gremlin installations require authentication with our Gremlin control plane. There are two types of authentication available to Gremlin and Helm: `certificate`, and `secret`. You can find out more about these authentication types [here](https://www.gremlin.com/docs/infrastructure-layer/authentication/).
 
 For this Helm chart, you'll need to download your team certificate or team secret from the Gremlin app.
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -80,7 +80,7 @@ helm delete --purge my-gremlin
 
 Some find it preferable to have this chart manage Gremlin's secret values instead of administrating them outside of Helm.
 
-```
+```shell
 helm install gremlin/gremlin \
     --name gremlin \
     --namespace gremlin \
@@ -91,7 +91,7 @@ helm install gremlin/gremlin \
     --set-file gremlin.secret.key=gremlin.key
 ```
 
-```
+```shell
 helm install gremlin/gremlin \
     --name gremlin \
     --namespace gremlin \
@@ -110,7 +110,7 @@ If you do not want this Chart to manage the kubernetes secrets for Gremlin, poin
 ##### For secret auth
 Create the external secret
 
-```bash
+```shell
 kubectl create secret --namespace gremlin \
     --from-literal=GREMLIN_TEAM_ID=deadbeef \
     --from-literal=GREMLIN_TEAM_SECRET=5ec4e7 \
@@ -119,7 +119,7 @@ kubectl create secret --namespace gremlin \
 
 Install the Helm chart
 
-```bash
+```shell
 helm install gremlin/gremlin \
     --name gremlin \
     --set gremlin.secret.name=gremlin-team-secret \
@@ -130,7 +130,7 @@ helm install gremlin/gremlin \
 
 Create the external secret
 
-```bash
+```shell
 kubectl create secret --namespace gremlin \
     --from-literal=GREMLIN_TEAM_ID=deadbeef \
     --from-literal=GREMLIN_CLUSTER_ID=my-cluster \
@@ -138,7 +138,7 @@ kubectl create secret --namespace gremlin \
     --from-file=gremlin.key=/path/to/gremlin.key
 ```
 
-```
+```shell
 helm install gremlin/gremlin \
     --name gremlin \
     --set gremlin.secret.name=gremlin-team-cert

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -46,7 +46,7 @@ In later versions of this chart, we will remove the use of `.Values.gremlin.clie
 {{- end -}}
 
 {{/*
-Create a computed value for the inteded Gremlin secret type which can either be `certificate` or `secret`
+Create a computed value for the intended Gremlin secret type which can either be `certificate` or `secret`
 */}}
 {{- define "gremlin.secretType" -}}
 {{- if .Values.gremlin.secret.type -}}

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -30,3 +30,38 @@ Create chart name and version as used by the chart label.
 {{- define "gremlin.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Because we've evolved the recommended way to pass the secret name over time, we hide the following order of operations behind this computed value:
+In later versions of this chart, we will remove the use of `.Values.gremlin.client.secretName` and the fallback value of `gremlin-team-cert`
+*/}}
+{{- define "gremlin.secretName" -}}
+{{- $defaultName := "" -}}
+{{- if .Values.gremlin.secret.managed -}}
+{{- $defaultName = "gremlin-secret" -}}
+{{- else -}}
+{{- $defaultName = "gremlin-team-cert" -}}
+{{- end -}}
+{{- default .Values.gremlin.client.secretName .Values.gremlin.secret.name | default $defaultName -}}
+{{- end -}}
+
+{{/*
+Create a computed value for the inteded Gremlin secret type which can either be `certificate` or `secret`
+*/}}
+{{- define "gremlin.secretType" -}}
+{{- if .Values.gremlin.secret.type -}}
+{{- .Values.gremlin.secret.type -}}
+{{- else -}}
+{{- if .Values.gremlin.client.certCreateSecret -}}
+{{- "certificate" -}}
+{{- else if .Values.gremlin.secret.managed -}}
+{{- if .Values.gremlin.secret.teamSecret -}}
+{{- "secret" -}}
+{{- else -}}
+{{- "certificate" -}}
+{{- end -}}
+{{- else -}}
+{{- "certificate" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -25,17 +25,44 @@ spec:
       serviceAccountName: chao
       containers:
         - image: gremlin/chao:latest
+          env:
+            - name: GREMLIN_TEAM_ID
+{{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
+{{- if (and (not .Values.gremlin.secret.managed) (default .Values.gremlin.teamID .Values.gremlin.secret.teamID)) }}
+              value: {{ default .Values.gremlin.teamID .Values.gremlin.secret.teamID | quote }}
+{{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name:  {{ include "gremlin.secretName" . }}
+                  key: GREMLIN_TEAM_ID
+{{- end }}
+            - name: GREMLIN_CLUSTER_ID
+{{- /* If we aren't managing this secret and a clusterID was supplied, assume clusterID is not in the external secret */}}
+{{- if (and (not .Values.gremlin.secret.managed) (default .Values.gremlin.clusterID .Values.gremlin.secret.clusterID)) }}
+              value: {{ default .Values.gremlin.clusterID .Values.gremlin.secret.clusterID | quote }}
+{{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name:  {{ include "gremlin.secretName" . }}
+                  key: GREMLIN_CLUSTER_ID
+{{- end }}
+{{- if (eq (include "gremlin.secretType" .) "secret") }}
+            - name: GREMLIN_TEAM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gremlin.secretName" . }}
+                  key: GREMLIN_TEAM_SECRET
+{{- end }}
+{{- if (eq (include "gremlin.secretType" .) "certificate") }}
           args:
-          - "-team_id"
-          - {{ .Values.gremlin.teamID }}
-          - "-cluster_id"
-          - {{ .Values.gremlin.clusterID }}
           - "-cert_path"
           - "/var/lib/gremlin/cert/gremlin.cert"
           - "-key_path"
           - "/var/lib/gremlin/cert/gremlin.key"
+{{- end }}
           imagePullPolicy: Always
           name: chao
+{{- if (eq (include "gremlin.secretType" .) "certificate") }}
           volumeMounts:
           - name: gremlin-cert
             mountPath: /var/lib/gremlin/cert
@@ -43,7 +70,8 @@ spec:
       volumes:
       - name: gremlin-cert
         secret:
-          secretName: gremlin-team-cert
+          secretName: {{ include "gremlin.secretName" . }}
+{{ end }}
 ---
 {{ end }}
 

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -55,11 +55,28 @@ spec:
               - KILL
         env:
           - name: GREMLIN_TEAM_ID
-            value: {{ .Values.gremlin.teamID }}
+            {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
+            {{- if (and (not .Values.gremlin.secret.managed) (default .Values.gremlin.teamID .Values.gremlin.secret.teamID)) }}
+            value: {{ default .Values.gremlin.teamID .Values.gremlin.secret.teamID | quote }}
+            {{- else }}
+            valueFrom:
+              secretKeyRef:
+                name:  {{ include "gremlin.secretName" . }}
+                key: GREMLIN_TEAM_ID
+            {{- end }}
+
+          {{- if (eq (include "gremlin.secretType" .) "secret") }}
+          - name: GREMLIN_TEAM_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "gremlin.secretName" . }}
+                key: GREMLIN_TEAM_SECRET
+          {{- else }}
           - name: GREMLIN_TEAM_CERTIFICATE_OR_FILE
-            value: {{ trimSuffix "\n" .Values.gremlin.client.cert }}
+            value: file:///var/lib/gremlin/cert/gremlin.cert
           - name: GREMLIN_TEAM_PRIVATE_KEY_OR_FILE
-            value: {{ trimSuffix "\n" .Values.gremlin.client.key }}
+            value: file:///var/lib/gremlin/cert/gremlin.key
+          {{- end }}
           - name: GREMLIN_IDENTIFIER
             valueFrom:
               fieldRef:
@@ -77,9 +94,11 @@ spec:
             mountPath: /var/log/gremlin
           - name: shutdown-trigger
             mountPath: /sysrq
+          {{- if (eq (include "gremlin.secretType" .) "certificate") }}
           - name: gremlin-cert
             mountPath: /var/lib/gremlin/cert
             readOnly: true
+          {{- end }}
       volumes:
         # Gremlin uses the Docker socket to discover eligible containers to attack,
         # and to launch Gremlin sidecar containers
@@ -100,7 +119,8 @@ spec:
         - name: shutdown-trigger
           hostPath:
             path: /proc/sysrq-trigger
-        # Distribute the certificate and key
+        {{- if (eq (include "gremlin.secretType" .) "certificate") }}
         - name: gremlin-cert
           secret:
-            secretName: {{ .Values.gremlin.client.secretName }}
+            secretName: {{ include "gremlin.secretName" . }}
+        {{- end }}

--- a/gremlin/templates/secret.yaml
+++ b/gremlin/templates/secret.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.gremlin.client.certCreateSecret }}
+{{- if (default .Values.gremlin.client.certCreateSecret .Values.gremlin.secret.managed) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.gremlin.client.secretName }}
+  name: {{ include "gremlin.secretName" . }}
   labels:
     app.kubernetes.io/name: {{ include "gremlin.name" . }}
     helm.sh/chart: {{ include "gremlin.chart" . }}
@@ -11,7 +11,16 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     version: v1
 type: kubernetes.io/Opaque
+stringData:
+  GREMLIN_CLUSTER_ID: {{ default .Values.gremlin.clusterID .Values.gremlin.secret.clusterID | required "required: .Values.gremlin.secret.clusterID" | toString }}
+  GREMLIN_TEAM_ID: {{ default .Values.gremlin.teamID .Values.gremlin.secret.teamID | required "required: .Values.gremlin.secret.teamID" | toString }}
+{{- if (eq (include "gremlin.secretType" .) "secret") }}
+  GREMLIN_TEAM_SECRET: {{ .Values.gremlin.secret.teamSecret | required "required: .Values.gremlin.secret.teamSecret" |  toString }}
+{{- else if (eq (include "gremlin.secretType" .) "certificate") }}
+  GREMLIN_TEAM_CERTIFICATE_OR_FILE: file:///var/lib/gremlin/cert/gremlin.cert
+  GREMLIN_TEAM_PRIVATE_KEY_OR_FILE: file:///var/lib/gremlin/cert/gremlin.key
 data:
-  gremlin.cert: {{ required "A valid .Values.gremlin.client.certContent entry required!" .Values.gremlin.client.certContent | toString | b64enc }}
-  gremlin.key: {{ required "A valid .Values.gremlin.client.keyContent entry required!" .Values.gremlin.client.keyContent | toString | b64enc }}
+  gremlin.cert: {{ default .Values.gremlin.client.certContent .Values.gremlin.secret.certificate | required "required: .Values.gremlin.secret.certificate" | toString | b64enc }}
+  gremlin.key: {{ default .Values.gremlin.client.keyContent .Values.gremlin.secret.key | required "required: .Values.gremlin.secret.key" | toString | b64enc }}
+{{- end }}
 {{- end }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -32,8 +32,8 @@ gremlin:
     # NOTE: `certificate`+`key` OR `secret` is required, not both. `type` dictates which will be used
     # type: certificate
     # managed: true
-    # teamID: e7352a6b-a9a0-513c-81e4-980f680a70c2
+    # teamID: 1d1d1d1d-1d1d-1d1d-1d1d-1d1d1d1d1d1d
     # clusterID: my-cluster-id
-    # certificate: '-----BEGIN CERTIFICATE-----\nMIIBsjCCAVigAwIBAgIBATAKBggqhkjOPQQDAjBTMSMwIQYDVQQDDBpHcmVtbGlu\nIENsaWVudCBDZXJ0aWZpY2F0ZTEVMBMGA1UECwwMR3JlbWxpbiBJbmMuMRUwEwYD\nVQQKDAxHcmVtbGluIEluYy4wHhcNMTkxMDEwMDY1NDEyWhcNMjAxMDA5MDY1NDEy\nWjBTMSMwIQYDVQQDDBpHcmVtbGluIENsaWVudCBDZXJ0aWZpY2F0ZTEVMBMGA1UE\nCwwMR3JlbWxpbiBJbmMuMRUwEwYDVQQKDAxHcmVtbGluIEluYy4wWTATBgcqhkjO\nPQIBBggqhkjOPQMBBwNCAASibCF99hulTHhlngJE+tf2svxDJYoeo4wdcvneww8e\n7HQsofGjnAZlGRXYo8Fwf4Na+2rV41YYCg/5MOU5Vw9/ox0wGzAJBgNVHRMEAjAA\nMA4GA1UdDwEB/wQEAwIHgDAKBggqhkjOPQQDAgNIADBFAiEAwZjyROE8tBZkf/vA\nIyheUuk8fwjg56eH06c/rnvWUGYCIAaHZL8qryIDbQ/byeQhRezTHOTB8g95SLM8\nScH02pXi\n-----END CERTIFICATE-----\n'
-    # key: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIHgi79kb1QAdfNbi3ZKybeFNklWYfUqxz7mN1dHAaQsCoAoGCCqGSM49\nAwEHoUQDQgAEomwhffYbpUx4ZZ4CRPrX9rL8QyWKHqOMHXL53sMPHux0LKHxo5wG\nZRkV2KPBcH+DWvtq1eNWGAoP+TDlOVcPfw==\n-----END EC PRIVATE KEY-----\n'
+    # certificate: -----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----
+    # key: -----BEGIN EC PRIVATE KEY-----...-----END EC PRIVATE KEY-----
     # teamSecret: 5ec4e75e-c4e7-5ec4-e75e-c4e75ec4e75e

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -18,18 +18,22 @@ affinity: {}
 
 gremlin:
   apparmor: ""
-  teamID: ""
+  teamID: ""                    # DEPRECATED: moved to gremlin.secret.teamID
+  clusterID: ""                 # DEPRECATED: moved to gremlin.secret.clusterID
   hostPID: false
   hostNetwork: false
   installK8sClient: true
   client:
-    secretName: gremlin-team-cert
-    cert: file:///var/lib/gremlin/cert/gremlin.cert
-    key: file:///var/lib/gremlin/cert/gremlin.key
     tags: ""
-
-    # # Uncomment and fill this block to have Helm create the secret
-    # # populated with your Gremlin key and cert
-    # certCreateSecret: true
-    # certContent: ""
-    # keyContent: ""
+  secret: {}
+    # Gremlin supports both `certificate` and `secret` types
+    # # By default, Gremlin will not manage secret values
+    # # To manage secrets with helm, uncomment the following
+    # NOTE: `certificate`+`key` OR `secret` is required, not both. `type` dictates which will be used
+    # type: certificate
+    # managed: true
+    # teamID: e7352a6b-a9a0-513c-81e4-980f680a70c2
+    # clusterID: my-cluster-id
+    # certificate: '-----BEGIN CERTIFICATE-----\nMIIBsjCCAVigAwIBAgIBATAKBggqhkjOPQQDAjBTMSMwIQYDVQQDDBpHcmVtbGlu\nIENsaWVudCBDZXJ0aWZpY2F0ZTEVMBMGA1UECwwMR3JlbWxpbiBJbmMuMRUwEwYD\nVQQKDAxHcmVtbGluIEluYy4wHhcNMTkxMDEwMDY1NDEyWhcNMjAxMDA5MDY1NDEy\nWjBTMSMwIQYDVQQDDBpHcmVtbGluIENsaWVudCBDZXJ0aWZpY2F0ZTEVMBMGA1UE\nCwwMR3JlbWxpbiBJbmMuMRUwEwYDVQQKDAxHcmVtbGluIEluYy4wWTATBgcqhkjO\nPQIBBggqhkjOPQMBBwNCAASibCF99hulTHhlngJE+tf2svxDJYoeo4wdcvneww8e\n7HQsofGjnAZlGRXYo8Fwf4Na+2rV41YYCg/5MOU5Vw9/ox0wGzAJBgNVHRMEAjAA\nMA4GA1UdDwEB/wQEAwIHgDAKBggqhkjOPQQDAgNIADBFAiEAwZjyROE8tBZkf/vA\nIyheUuk8fwjg56eH06c/rnvWUGYCIAaHZL8qryIDbQ/byeQhRezTHOTB8g95SLM8\nScH02pXi\n-----END CERTIFICATE-----\n'
+    # key: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIHgi79kb1QAdfNbi3ZKybeFNklWYfUqxz7mN1dHAaQsCoAoGCCqGSM49\nAwEHoUQDQgAEomwhffYbpUx4ZZ4CRPrX9rL8QyWKHqOMHXL53sMPHux0LKHxo5wG\nZRkV2KPBcH+DWvtq1eNWGAoP+TDlOVcPfw==\n-----END EC PRIVATE KEY-----\n'
+    # teamSecret: 5ec4e75e-c4e7-5ec4-e75e-c4e75ec4e75e


### PR DESCRIPTION
This PR consolidates all existing ways to configure Gremlin into the following helm values
```
gremlin.secret.managed     = true|false
gremlin.secret.type        = secret|certificate
gremlin.secret.name        = name of external k8s secret
gremlin.secret.clusterID   = YOUR-CLUSTER-ID
gremlin.secret.teamID      = YOUR-TEAM-ID
gremlin.secret.teamSecret  = YOUR-TEAM-SECRET
gremlin.secret.certificate = /path/to/cert
gremlin.secret.key         = /path/to/key
```

For an externally managed secret, only `managed`, `type`, and `name` are required. Other values can be supplied as overrides (e.g. `clusterID` and `teamID`)