### PR TITLE
Updated spec to allow overriding the repository/name/tag of the chao …

### DIFF
--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -17,6 +17,9 @@ their default values. See values.yaml for all available options.
 | `image.pullPolicy`                     | Container pull policy                                          | `Always`                                                                    |
 | `image.repository`                     | Container image to use                                         | `gremlin/gremlin`                                                           |
 | `image.tag`                            | Container image tag to deploy                                  | `latest`                                                                    |
+| `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
+| `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
+| `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
 | `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       serviceAccountName: chao
       containers:
-        - image: gremlin/chao:latest
+        - image: {{ .Values.chaoimage.repository }}:{{ .Values.chaoimage.tag }}
           env:
             - name: GREMLIN_TEAM_ID
 {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
@@ -60,7 +60,7 @@ spec:
           - "-key_path"
           - "/var/lib/gremlin/cert/gremlin.key"
 {{- end }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.chaoimage.pullPolicy }}
           name: chao
 {{- if (eq (include "gremlin.secretType" .) "certificate") }}
           volumeMounts:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -7,6 +7,11 @@ image:
   tag: latest
   pullPolicy: Always
 
+chaoimage:
+  repository: gremlin/chao
+  tag: latest
+  pullPolicy: Always
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
This is to allow folks using private container repositories (e.g JPMC) to deploy the chao container using their own internal spec.