### PR TITLE
Add support for setting resources

### DIFF
--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -23,6 +23,8 @@ their default values. See values.yaml for all available options.
 | `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |
+| `resources`                            | Map of node/pod resources                                      | `{}`
+                                                                    |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.secret.managed`               | Specifies whether Gremlin should manage its secrets with Helm  | `false`                                                                     |
 | `gremlin.secret.type`                  | The type of certificate to use, can be either `certificate` or `secret` | `certificate`                                                      |

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -25,6 +25,10 @@ spec:
       serviceAccountName: chao
       containers:
         - image: {{ .Values.chaoimage.repository }}:{{ .Values.chaoimage.tag }}
+        {{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | trimSuffix "\n" | indent 12 }}
+        {{- end }}
           env:
             - name: GREMLIN_TEAM_ID
 {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -46,6 +46,10 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         args: [ "daemon" ]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | trimSuffix "\n" | indent 10 }}
+        {{- end }}
         securityContext:
           capabilities:
             add:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -21,6 +21,10 @@ tolerations: []
 
 affinity: {}
 
+
+resources: {} 
+
+
 gremlin:
   apparmor: ""
   teamID: ""                    # DEPRECATED: moved to gremlin.secret.teamID


### PR DESCRIPTION
Add support for setting container resources. 

Helm Client Version: 2.13.1

Expected format in values.yml is:
```
resources:  
  limits:
    memory: xMi
  requests:
    cpu: ym
    memory: zMi

```


Helm Template output:

```
# Source: gremlin/templates/chao-service-account.yaml

apiVersion: v1
kind: ServiceAccount
metadata:
  name: chao
  namespace: default
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: gremlin-watcher
rules:
  - apiGroups: ["apps"]
    resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
    verbs: ["get", "watch", "list"]
  - apiGroups: [""]
    resources: ["pods", "nodes"]
    verbs: ["get", "watch", "list"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: chao
subjects:
  - kind: ServiceAccount
    name: chao
    namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: gremlin-watcher
---


---
# Source: gremlin/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: release-name-gremlin
  namespace: default
  labels:
    app.kubernetes.io/name: gremlin
    helm.sh/chart: gremlin-0.1.8
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Tiller
    version: v1
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: gremlin
  template:
    metadata:
      labels:
        app.kubernetes.io/name: gremlin
        helm.sh/chart: gremlin-0.1.8
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Tiller
        version: v1
    spec:
      hostPID: false
      hostNetwork: false
      containers:
      - name: gremlin
        image: gremlin/gremlin:latest
        args: [ "daemon" ]
        imagePullPolicy: Always
        resources:
          limits:
            memory: 200Mi
          requests:
            cpu: 100m
            memory: 200Mi
        securityContext:
          capabilities:
            add:
              - NET_ADMIN
              - SYS_BOOT
              - SYS_TIME
              - KILL
        env:
          - name: GREMLIN_TEAM_ID
            valueFrom:
              secretKeyRef:
                name:  gremlin-team-cert
                key: GREMLIN_TEAM_ID
          - name: GREMLIN_TEAM_CERTIFICATE_OR_FILE
            value: file:///var/lib/gremlin/cert/gremlin.cert
          - name: GREMLIN_TEAM_PRIVATE_KEY_OR_FILE
            value: file:///var/lib/gremlin/cert/gremlin.key
          - name: GREMLIN_IDENTIFIER
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
          - name: GREMLIN_CLIENT_TAGS
            value:
          - name: GREMLIN_DOCKER_IMAGE
            value: gremlin/gremlin:latest
        volumeMounts:
          - name: docker-sock
            mountPath: /var/run/docker.sock
          - name: gremlin-state
            mountPath: /var/lib/gremlin
          - name: gremlin-logs
            mountPath: /var/log/gremlin
          - name: shutdown-trigger
            mountPath: /sysrq
          - name: gremlin-cert
            mountPath: /var/lib/gremlin/cert
            readOnly: true
      volumes:
        # Gremlin uses the Docker socket to discover eligible containers to attack,
        # and to launch Gremlin sidecar containers
        - name: docker-sock
          hostPath:
            path: /var/run/docker.sock
        # The Gremlin daemon communicates with Gremlin sidecars via its state directory.
        # This should be shared with the Kubernetes host
        - name: gremlin-state
          hostPath:
            path: /var/lib/gremlin
        # The Gremlin daemon forwards logs from the Gremlin sidecars to the Gremlin control plane
        # These logs should be shared with the host
        - name: gremlin-logs
          hostPath:
            path: /var/log/gremlin
        # If you want to run shutdown attacks on the host, the Gremlin Daemon requires a /proc/sysrq-trigger:/sysrq mount
        - name: shutdown-trigger
          hostPath:
            path: /proc/sysrq-trigger
        - name: gremlin-cert
          secret:
            secretName: gremlin-team-cert

---
# Source: gremlin/templates/chao-deployment.yaml

apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/instance: chao
    app.kubernetes.io/name: chao
    app.kubernetes.io/version: "1"
  name: chao
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: chao
      app.kubernetes.io/name: chao
      app.kubernetes.io/version: "1"
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: chao
        app.kubernetes.io/name: chao
        app.kubernetes.io/version: "1"
    spec:
      serviceAccountName: chao
      containers:
        - image: gremlin/chao:latest
          resources:
            limits:
              memory: 200Mi
            requests:
              cpu: 100m
              memory: 200Mi
          env:
            - name: GREMLIN_TEAM_ID
              valueFrom:
                secretKeyRef:
                  name:  gremlin-team-cert
                  key: GREMLIN_TEAM_ID
            - name: GREMLIN_CLUSTER_ID
              valueFrom:
                secretKeyRef:
                  name:  gremlin-team-cert
                  key: GREMLIN_CLUSTER_ID
          args:
          - "-cert_path"
          - "/var/lib/gremlin/cert/gremlin.cert"
          - "-key_path"
          - "/var/lib/gremlin/cert/gremlin.key"
          imagePullPolicy: Always
          name: chao
          volumeMounts:
          - name: gremlin-cert
            mountPath: /var/lib/gremlin/cert
            readOnly: true
      volumes:
      - name: gremlin-cert
        secret:
          secretName: gremlin-team-cert

---

```