### PR TITLE
add required capabilities SYS_CHROOT and NET_RAW

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.2.1
+version: 0.2.2
 description: The Gremlin Inc client application
 appVersion: "2.16.2"
 apiVersion: v1

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -123,6 +123,13 @@ gremlin:
       - MKNOD       # Required by container drivers: docker-runc, crio-runc, containerd-runc
                     #   to create new devices for Gremlin attack sidecars
 
+      - SYS_CHROOT  # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   to create and enter new namespaces for Gremlin attack sidecars
+
+      - NET_RAW     # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   Not actively used by Gremlin but requested by sidecars
+                    #   This capability will be removed in a later release
+
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem
     readOnlyRootFilesystem: false


### PR DESCRIPTION
**Background**

Gremlin has been using capabilities provided by default: `CAP_SYS_CHROOT` and `CAP_NET_RAW`.

Newer versions of Crio and/or OpenShift have changed the default capabilities provided to new containers. Two capabilities Gremlin needs were dropped:

* CAP_NET_RAW (gremlin technically doesn't need this but it does request it, see https://gremlininc.atlassian.net/browse/EN-561)

* CAP_SYS_CHROOT (required to create and enter namespaces of our sidecars)

**Change**

* add declaration for the above needed caps

**Testing**

* Create a kubernetes environment (e.g. ` minikube start --container-runtime=crio`)
* Install Gremlin according to [our documentation][criodoc]
* Run an attack against a pod or container

Observe attack successfully starts where it previously failed without this change.

[criodoc]: https://www.gremlin.com/docs/infrastructure-layer/install-crio-containerd/