### PR TITLE
remove unnecessary capabilities to adhere to PoLP

### DIFF
--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -114,21 +114,8 @@ gremlin:
       - SYS_PTRACE  # Required by container drivers: docker-runc, crio-runc, containerd-runc
                     #   to determine if Gremlin is in the host's pid namespace
 
-      - SETFCAP     # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to set capabilities on Gremlin attack sidecars
-
-      - AUDIT_WRITE # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to write to the Kernel's audit log
-
-      - MKNOD       # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to create new devices for Gremlin attack sidecars
-
       - SYS_CHROOT  # Required by container drivers: docker-runc, crio-runc, containerd-runc
                     #   to create and enter new namespaces for Gremlin attack sidecars
-
-      - NET_RAW     # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   Not actively used by Gremlin but requested by sidecars
-                    #   This capability will be removed in a later release
 
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem


### PR DESCRIPTION
**Background**

The Gremlin Agent Daemonset exposes various capabilities needed to:
1. carry out attacks within the Daemonset pods
2. carry out container initialization operations like entering the net/pid namespaces of other containers
3. appease [the default container spec][ociruntimetool] provided by our 3rd party libraries (even when it contains capabilities we do not need)

Gremlin should try to always adhere to the principle of least privilege (PoLP), and so the capabilities that fall under `#3` should be removed. This will require a new agent release.

**Change**

* Remove capabilities Gremlin does not need when it no longer leverages the capabilities provided by oci-runtime-tool's default capabilities set.

**Testing**

- [ ] test on openshift 3.x
- [x] test on openshift 4.x
- [ ] test on plain crio-based cluster
- [ ] test on plain containerd-based cluster

[ociruntimetool]: https://github.com/opencontainers/runtime-tools/blob/59cdde06764be8d761db120664020f0415f36045/generate/generate.go#L92