### PR TITLE
expose gremlin.proxy.url to configure Gremlin with http_proxy

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.2.2
+version: 0.2.3
 description: The Gremlin Inc client application
 appVersion: "2.16.2"
 apiVersion: v1

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -57,8 +57,8 @@ their default values. See values.yaml for all available options.
 | `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`                                                                        |
 | `gremlin.installK8sClient`             | Enable kubernetes targeting by installing k8s client           |  true                                                                       |
 | `gremlin.proxy.url`                    | Specifies the http proxy the agent should use to communicate with api.gremlin.com. |  `""` (ignored) |                                        |
-| `ssl.certFile`                         | sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. |  `""` (ignored) |
-| `ssl.certDir`                          | sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. |  `""` (ignored) | 
+| `ssl.certFile`                         | Add a certificate file to Gremlin's set of certificate authorities. This argument expects a file containing the certificate(s) you wish to add. When set, this chart creates secret (`ssl-cert-file`) with the contents and passes it to both agents. This value is ignored when blank or absent. |  `""` (ignored) |
+| `ssl.certDir`                          | sets the SSL_CERT_DIR environment variable on the both agents. Unlike ssl.certFile, this value accepts only a path to an existing directory on the Kubernetes nodes. This value is ignored when blank or absent. |  `""` (ignored) | 
 
 Specify each parameter using the `--set[-file] key=value[,key=value]` argument to `helm install`.
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -56,6 +56,7 @@ their default values. See values.yaml for all available options.
 | `gremlin.hostNetwork`                  | Enable host-level network attacks                              | `false`                                                                     |
 | `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`                                                                        |
 | `gremlin.installK8sClient`             | Enable kubernetes targeting by installing k8s client           |  true                                                                       |
+| `gremlin.proxy.url`                    | Specifies the http proxy the agent should use to communicate with api.gremlin.com. |  `""` (no proxy)                                        |
 
 Specify each parameter using the `--set[-file] key=value[,key=value]` argument to `helm install`.
 
@@ -162,6 +163,21 @@ kubectl create secret generic gremlin-team-cert \
 helm install gremlin gremlin/gremlin \
     --namespace gremlin \
     --set gremlin.secret.name=gremlin-team-cert
+```
+
+### With an HTTP_PROXY
+
+Gremlin can be configured to communicate with api.gremlin.com through an http_proxy. You can set this proxy with `gremlin.proxy.url`.
+
+```shell
+helm install gremlin gremlin/gremlin \
+    --namespace gremlin \
+    --set      gremlin.secret.managed=true \
+    --set      gremlin.secret.teamID=$GREMLIN_TEAM_ID \
+    --set      gremlin.secret.clusterID=$GREMLIN_CLUSTER_ID \
+    --set-file gremlin.secret.certificate=/path/to/gremlin.cert \
+    --set-file gremlin.secret.key=/path/to/gremlin.key \
+    --set      gremlin.proxy.url=http://localhost:3128
 ```
 
 ## Uninstallation

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -56,9 +56,9 @@ their default values. See values.yaml for all available options.
 | `gremlin.hostNetwork`                  | Enable host-level network attacks                              | `false`                                                                     |
 | `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`                                                                        |
 | `gremlin.installK8sClient`             | Enable kubernetes targeting by installing k8s client           |  true                                                                       |
-| `gremlin.proxy.url`                    | Specifies the http proxy the agent should use to communicate with api.gremlin.com. |  `""` (no proxy)                                        |
-| `ssl.certFile`                         | sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. Ignored when blank or unset. | `""` |            |
-| `ssl.certDir`                          | sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. Ignored when blank or unset. | `""` | 
+| `gremlin.proxy.url`                    | Specifies the http proxy the agent should use to communicate with api.gremlin.com. |  `""` (ignored) |                                        |
+| `ssl.certFile`                         | sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. |  `""` (ignored) |
+| `ssl.certDir`                          | sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. |  `""` (ignored) | 
 
 Specify each parameter using the `--set[-file] key=value[,key=value]` argument to `helm install`.
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -57,6 +57,8 @@ their default values. See values.yaml for all available options.
 | `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`                                                                        |
 | `gremlin.installK8sClient`             | Enable kubernetes targeting by installing k8s client           |  true                                                                       |
 | `gremlin.proxy.url`                    | Specifies the http proxy the agent should use to communicate with api.gremlin.com. |  `""` (no proxy)                                        |
+| `ssl.certFile`                         | sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. Ignored when blank or unset. | `""` |            |
+| `ssl.certDir`                          | sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. Ignored when blank or unset. | `""` | 
 
 Specify each parameter using the `--set[-file] key=value[,key=value]` argument to `helm install`.
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -179,7 +179,21 @@ helm install gremlin gremlin/gremlin \
     --set      gremlin.secret.clusterID=$GREMLIN_CLUSTER_ID \
     --set-file gremlin.secret.certificate=/path/to/gremlin.cert \
     --set-file gremlin.secret.key=/path/to/gremlin.key \
-    --set      gremlin.proxy.url=http://localhost:3128
+    --set      gremlin.proxy.url=http://proxy.net:3128
+```
+
+#### HTTPS_PROXY with custom certificate authority
+
+```shell
+helm install gremlin gremlin/gremlin \
+    --namespace gremlin \
+    --set      gremlin.secret.managed=true \
+    --set      gremlin.secret.teamID=$GREMLIN_TEAM_ID \
+    --set      gremlin.secret.clusterID=$GREMLIN_CLUSTER_ID \
+    --set-file gremlin.secret.certificate=/path/to/gremlin.cert \
+    --set-file gremlin.secret.key=/path/to/gremlin.key \
+    --set      gremlin.proxy.url=https://proxy.net:3128 \
+    --set-file ssl.certFile=$HOME/Workspace/proxy/ca.pem
 ```
 
 ## Uninstallation

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -63,6 +63,13 @@ spec:
             - name: no_proxy
               value: $(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
 {{- end }}
+{{- if .Values.ssl.certFile }}
+            - name: SSL_CERT_FILE
+              value: {{ .Values.ssl.certFile }}
+{{- end }}{{- if .Values.ssl.certDir }}
+            - name: SSL_CERT_DIR
+              value: {{ .Values.ssl.certDir }}
+{{- end }}
           args:
             - "-api_url"
             - "{{ include "gremlinServiceUrl" . }}/kubernetes"

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -66,7 +66,8 @@ spec:
 {{- if .Values.ssl.certFile }}
             - name: SSL_CERT_FILE
               value: {{ .Values.ssl.certFile }}
-{{- end }}{{- if .Values.ssl.certDir }}
+{{- end }}
+{{- if .Values.ssl.certDir }}
             - name: SSL_CERT_DIR
               value: {{ .Values.ssl.certDir }}
 {{- end }}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -65,7 +65,7 @@ spec:
 {{- end }}
 {{- if .Values.ssl.certFile }}
             - name: SSL_CERT_FILE
-              value: {{ .Values.ssl.certFile }}
+              value: /etc/gremlin/ssl/certfile.pem
 {{- end }}
 {{- if .Values.ssl.certDir }}
             - name: SSL_CERT_DIR
@@ -87,10 +87,20 @@ spec:
           - name: gremlin-cert
             mountPath: /var/lib/gremlin/cert
             readOnly: true
+          {{- if .Values.ssl.certFile }}
+          - name: ssl-cert-file
+            mountPath: /etc/gremlin/ssl
+            readOnly: true
+          {{- end }}
       volumes:
       - name: gremlin-cert
         secret:
           secretName: {{ include "gremlin.secretName" . }}
+      {{- if .Values.ssl.certFile }}
+      - name: ssl-cert-file
+        secret:
+          secretName: ssl-cert-file
+      {{- end }}
 {{ end }}
 ---
 {{ end }}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -57,6 +57,12 @@ spec:
                   name: {{ include "gremlin.secretName" . }}
                   key: GREMLIN_TEAM_SECRET
 {{- end }}
+{{- if .Values.gremlin.proxy.url }}
+            - name: https_proxy
+              value: {{ .Values.gremlin.proxy.url }}
+            - name: no_proxy
+              value: $(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
+{{- end }}
           args:
             - "-api_url"
             - "{{ include "gremlinServiceUrl" . }}/kubernetes"

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -111,6 +111,10 @@ spec:
           - name: https_proxy
             value: {{ .Values.gremlin.proxy.url }}
           {{- end }}
+          {{- if .Values.ssl.certFile }}
+          - name: SSL_CERT_FILE
+            value: {{ .Values.ssl.certFile }}
+          {{- end }}
         volumeMounts:
           - name: gremlin-state
             mountPath: /var/lib/gremlin

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -113,7 +113,11 @@ spec:
           {{- end }}
           {{- if .Values.ssl.certFile }}
           - name: SSL_CERT_FILE
-            value: {{ .Values.ssl.certFile }}
+            value: /etc/gremlin/ssl/certfile.pem
+          {{- end }}
+          {{- if .Values.ssl.certDir }}
+          - name: SSL_CERT_DIR
+            value: {{ .Values.ssl.certDir }}
           {{- end }}
         volumeMounts:
           - name: gremlin-state
@@ -138,6 +142,11 @@ spec:
           {{- if (eq (include "gremlin.secretType" .) "certificate") }}
           - name: gremlin-cert
             mountPath: /var/lib/gremlin/cert
+            readOnly: true
+          {{- end }}
+          {{- if .Values.ssl.certFile }}
+          - name: ssl-cert-file
+            mountPath: /etc/gremlin/ssl
             readOnly: true
           {{- end }}
       volumes:
@@ -177,4 +186,9 @@ spec:
         - name: seccomp-profile
           configMap:
             name: {{ template "gremlin.fullname" . }}-seccomp
+        {{- end }}
+        {{- if .Values.ssl.certFile }}
+        - name: ssl-cert-file
+          secret:
+            secretName: ssl-cert-file
         {{- end }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -107,6 +107,10 @@ spec:
           {{- end }}
           - name: GREMLIN_SERVICE_URL
             value: {{ include "gremlinServiceUrl" . }}
+          {{- if .Values.gremlin.proxy.url }}
+          - name: https_proxy
+            value: {{ .Values.gremlin.proxy.url }}
+          {{- end }}
         volumeMounts:
           - name: gremlin-state
             mountPath: /var/lib/gremlin

--- a/gremlin/templates/secret-ssl-cert-file.yaml
+++ b/gremlin/templates/secret-ssl-cert-file.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ssl.certFile }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssl-cert-file
+  labels:
+    app.kubernetes.io/name: {{ include "gremlin.name" . }}
+    helm.sh/chart: {{ include "gremlin.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    version: v1
+type: kubernetes.io/Opaque
+data:
+  certfile.pem: {{ default .Values.ssl.certFile | toString | b64enc }}
+{{- end }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -241,8 +241,10 @@ gremlin:
 
 ssl:
   # ssl.certFile -
-  # sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. Ignored when blank or unset.
+  # sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent.Ignored when blank or
+  # unset.
   certFile:
   # ssl.certDir -
-  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. Ignored when blank or unset.
+  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. Ignored
+  # when blank or unset.
   certDir:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -232,3 +232,9 @@ gremlin:
     ## Secret auth requires: `teamSecret`
     # team secret (e.g. 00000000-0000-0000-0000-000000000000)
     teamSecret:
+
+  proxy:
+    # gremlin.proxy.url -
+    # Specifies the http proxy that the Gremlin Agent and Gremlin Kubernetes agent should use to communicate with
+    # api.gremlin.com. This value is ignored when blank or absent.
+    url:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -241,10 +241,11 @@ gremlin:
 
 ssl:
   # ssl.certFile -
-  # sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. This value is ignored
-  # when blank or absent.
+  # Add a certificate file to Gremlin's set of certificate authorities. This argument expects a file containing the
+  # certificate(s) you wish to add. When set, this chart creates secret (`ssl-cert-file`) with the contents and passes
+  # it to both agents. This value is ignored when blank or absent.
   certFile:
   # ssl.certDir -
-  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. This
-  # value is ignored when blank or absent.
+  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. Unlike ssl.certFile, this value accepts only a
+  # path to an existing directory on the Kubernetes nodes. This value is ignored when blank or absent.
   certDir:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -246,6 +246,6 @@ ssl:
   # it to both agents. This value is ignored when blank or absent.
   certFile:
   # ssl.certDir -
-  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. Unlike ssl.certFile, this value accepts only a
+  # sets the SSL_CERT_DIR environment variable on the both agents. Unlike ssl.certFile, this value accepts only a
   # path to an existing directory on the Kubernetes nodes. This value is ignored when blank or absent.
   certDir:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -238,3 +238,11 @@ gremlin:
     # Specifies the http proxy that the Gremlin Agent and Gremlin Kubernetes agent should use to communicate with
     # api.gremlin.com. This value is ignored when blank or absent.
     url:
+
+ssl:
+  # ssl.certFile -
+  # sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. Ignored when blank or unset.
+  certFile:
+  # ssl.certDir -
+  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. Ignored when blank or unset.
+  certDir:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -241,10 +241,10 @@ gremlin:
 
 ssl:
   # ssl.certFile -
-  # sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent.Ignored when blank or
-  # unset.
+  # sets the SSL_CERT_FILE environment variable on both the Gremlin agent and Kubernetes agent. This value is ignored
+  # when blank or absent.
   certFile:
   # ssl.certDir -
-  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. Ignored
-  # when blank or unset.
+  # sets the SSL_CERT_DIR environment variable on the Kubernetes agent. The Gremlin agent ignores this variable. This
+  # value is ignored when blank or absent.
   certDir:


### PR DESCRIPTION
**Background**

Gremlin can be configured to communicate with api.gremlin.com through an http_proxy (See [documentation][proxydocs]). The Gremlin Helm chart exposes no mechanism for configuring Gremlin to use such a proxy.

**Change**

* create a new value `gremlin.proxy.url` whose default is `""`
* modify `daemonset.yaml` and `chao-deployment.yaml` to set `http_proxy` and `no_proxy` environment variables when this value is non-blank

**Testing**

* spun up Gremlin on `minikube` with and without proxy settings

```shell
 helm install gremlin ./gremlin \
  --namespace gremlin \
  --set      gremlin.secret.managed=true \
  --set      gremlin.secret.clusterID=test \
  --set      gremlin.secret.teamID=$GREMLIN_TEAM_ID \
  --set-file gremlin.secret.certificate=$PATH_TO_CERTIFICATE \
  --set-file gremlin.secret.key=$PATH_TO_PRIVATE_KEY \
  --set      gremlin.hostPID=true \
  --set      gremlin.collect.processes=true \
  --set      gremlin.proxy.url=http://host.docker.internal:3128
```

[proxydocs]: https://www.gremlin.com/docs/infrastructure-layer/kubernetes/#proxy-configuration