### PR TITLE
add level to SELinux options to address errors during attacks

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.2.2
+version: 0.3.0
 description: The Gremlin Inc client application
 appVersion: "2.16.2"
 apiVersion: v1

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -156,11 +156,12 @@ gremlin:
       # When true, Gremlin creates and uses a custom PodSecurityPolicy, granting all behaviors Gremlin needs
       create: false
       # gremlin.podSecurity.podSecurityPolicy.seLinux
-      # Sets the SecurityContext for the PSP used by the Gremlin Daemonset
+      # Sets the SecurityContext for the PSP used by the Gremlin Daemonset.
       seLinux:
         rule: MustRunAs
         seLinuxOptions:
           type: gremlin.process
+          level: s0-s0:c0.c1023
       # gremlin.podSecurity.podSecurityPolicy.runAsUser -
       # Specifies the Linux user the Gremlin Daemonset containers should run as
       runAsUser:
@@ -179,6 +180,7 @@ gremlin:
         type: MustRunAs
         seLinuxOptions:
           type: gremlin.process
+          level: s0-s0:c0.c1023
       # gremlin.podSecurity.securityContextConstraints.runAsUser -
       # Specifies the Linux user the Gremlin Daemonset containers should run as
       runAsUser:

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -156,7 +156,7 @@ gremlin:
       # When true, Gremlin creates and uses a custom PodSecurityPolicy, granting all behaviors Gremlin needs
       create: false
       # gremlin.podSecurity.podSecurityPolicy.seLinux
-      # Sets the SecurityContext for the PSP used by the Gremlin Daemonset.
+      # Sets the SecurityContext for the PSP used by the Gremlin Daemonset
       seLinux:
         rule: MustRunAs
         seLinuxOptions:


### PR DESCRIPTION
**Background**
This fixes issue #40

**Change**

Add a default level of `s0-s0:c0.c1023` which is permissive enough to grant `gremlin.process` access to read all files permitted by https://github.com/selinux-policies/.