### PR TITLE
move 0.4.0 out of pre-release

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.4.0-alpha
+version: 0.4.0
 description: The Gremlin Inc client application
 appVersion: "2.16.2"
 apiVersion: v1


### PR DESCRIPTION
This change moves our latest helm chart release out of pre-release and into GA. It includes

https://github.com/gremlin/helm/pull/46