### PR TITLE
Added an additional label of chart version used which will force recr…

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.4.0
+version: 0.4.1
 description: The Gremlin Inc client application
 appVersion: "2.16.2"
 apiVersion: v1

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: chao
     app.kubernetes.io/name: chao
+    helm.sh/chart: {{ include "gremlin.chart" . }}
     app.kubernetes.io/version: "1"
   name: chao
   namespace: {{ .Release.Namespace }}
@@ -20,6 +21,7 @@ spec:
       labels:
         app.kubernetes.io/instance: chao
         app.kubernetes.io/name: chao
+        helm.sh/chart: {{ include "gremlin.chart" . }}
         app.kubernetes.io/version: "1"
     spec:
       serviceAccountName: chao


### PR DESCRIPTION
Background: Updating the helm repo and then upgrading the helm release only restarts the gremlin pods but not the chao pod. We do want the chao pod to be restarted with the latest chao image in order to utilize the new permissions in the cluster role.

Change: Force recreation of the chao pod by adding the chart version label to `chao` Deployment similar to how we do for `gremlin` Daemonset

- Add the label `helm.sh/chart`
- Increment the patch version of the chart