### PR TITLE
Any container daemon

### DIFF
--- a/gremlin/examples/drivers/README.md
+++ b/gremlin/examples/drivers/README.md
@@ -6,6 +6,9 @@ is used to integrate with Docker, Cri-O, and Containerd respectively.
 In order to preserve the behaviors of previous versions of this chart, none of the above drivers are enabled by
 default. Instead, Gremlin will try to run under the legacy `docker` driver, which has [some limitations][cgroup-driver].
 
+You also have the option of specifying `all` which will mount the locations for all drivers and then gremlin will
+attempt to determine the correct one.  This can be a good options if you don't know which driver you have
+
 ## Requirements
 
 In order to use one of the recommended container drivers, you must run the Gremlin Daemonset in the host's PID namespace,

--- a/gremlin/examples/drivers/README.md
+++ b/gremlin/examples/drivers/README.md
@@ -6,8 +6,8 @@ is used to integrate with Docker, Cri-O, and Containerd respectively.
 In order to preserve the behaviors of previous versions of this chart, none of the above drivers are enabled by
 default. Instead, Gremlin will try to run under the legacy `docker` driver, which has [some limitations][cgroup-driver].
 
-You also have the option of specifying `all` which will mount the locations for all drivers and then gremlin will
-attempt to determine the correct one.  This can be a good options if you don't know which driver you have
+You also have the option of specifying `any` which will mount the locations for all supported drivers and then gremlin
+will attempt to determine the correct one.  This can be a good options if you don't know which driver you have
 
 ## Requirements
 

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -77,29 +77,20 @@ Create a computed value for the intended Gremlin secret type which can either be
 {{- end -}}
 {{- end -}}
 
-{{- define "runtimeSocket" -}}
+{{- define "containerRuntime" -}}
 {{- if eq "docker-runc" (include "containerDriverWithDefaultOrError" .) -}}
-{{- "/var/run/docker.sock" -}}
+{{- [.Values.containerDrivers.docker-runc] -}}
 {{- else if eq "containerd-runc" (include "containerDriverWithDefaultOrError" .) -}}
-{{- "/run/containerd/containerd.sock" -}}
+{{- [.Values.containerDrivers.containerd-runc] -}}
 {{- else if eq "crio-runc" (include "containerDriverWithDefaultOrError" .) -}}
-{{- "/run/crio/crio.sock" -}}
+{{- [.Values.containerDrivers.crio-runc] -}}
+{{- else if eq "all" (include "containerDriverWithDefaultOrError" .) -}}
+{{- [.Values.containerDrivers.docker-runc, .Values.containerDrivers.containerd-runc, .Values.containerDrivers.crio-runc] -}}
 {{- else -}}
-{{- "/var/run/docker.sock" -}}
+{{- [.Values.containerDrivers.docker-runc] -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "runtimeRunc" -}}
-{{- if eq "docker-runc" (include "containerDriverWithDefaultOrError" .) -}}
-{{- "/run/docker/runtime-runc/moby" -}}
-{{- else if eq "containerd-runc" (include "containerDriverWithDefaultOrError" .) -}}
-{{- "/run/containerd/runc/k8s.io" -}}
-{{- else if eq "crio-runc" (include "containerDriverWithDefaultOrError" .) -}}
-{{- "/run/runc" -}}
-{{- else -}}
-{{- "" -}}
-{{- end -}}
-{{- end -}}
 
 {{- define "pspApiVersion" -}}
 {{- if .Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -129,15 +129,17 @@ spec:
           - name: cgroup-root
             mountPath: /sys/fs/cgroup
             readOnly: true
-          - name: runtime-sock
-            mountPath: {{ include "runtimeSocket" . }}
-            readOnly: true
           - name: shutdown-trigger
             mountPath: /sysrq
-          {{- if include "runtimeRunc" . }}
+          {{- if include "containerRuntime" . }}
+          {{- range include "containerRuntime" .}}
+          - name: runtime-sock
+            mountPath: {{ .runtimeSocket }}
+            readOnly: true
           - name: runtime-runc
-            mountPath: {{ include "runtimeRunc" . }}
+            mountPath: {{ .runtimeRunc }}
             readOnly: false
+          {{- end }}
           {{- end }}
           {{- if (eq (include "gremlin.secretType" .) "certificate") }}
           - name: gremlin-cert
@@ -153,13 +155,15 @@ spec:
         - name: cgroup-root
           hostPath:
             path: {{ .Values.gremlin.cgroup.root }}
-        - name: runtime-sock
+        {{- if include "containerRuntime" . }}
+        {{- range include "containerRuntime" .}}
+        - name: {{ .name }}-sock
           hostPath:
-            path: {{ include "runtimeSocket" . }}
-        {{- if include "runtimeRunc" . }}
-        - name: runtime-runc
+            path: {{ .runtimeSocket }}
+        - name: {{ .name }}-runc
           hostPath:
-            path: {{ include "runtimeRunc" . }}
+            path: {{ .runtimeRunc }}
+        {{- end}}
         {{- end }}
         # The Gremlin daemon communicates with Gremlin sidecars via its state directory.
         # This should be shared with the Kubernetes host

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -135,15 +135,8 @@ spec:
             readOnly: true
           - name: shutdown-trigger
             mountPath: /sysrq
-          {{- if include "containerRuntime" . }}
-          {{- range include "containerRuntime" .}}
-          - name: runtime-sock
-            mountPath: {{ .runtimeSocket }}
-            readOnly: true
-          - name: runtime-runc
-            mountPath: {{ .runtimeRunc }}
-            readOnly: false
-          {{- end }}
+          {{- if include "containerMounts" . }}
+          {{- include "containerMounts" . | nindent 10 }}
           {{- end }}
           {{- if (eq (include "gremlin.secretType" .) "certificate") }}
           - name: gremlin-cert
@@ -159,15 +152,8 @@ spec:
         - name: cgroup-root
           hostPath:
             path: {{ .Values.gremlin.cgroup.root }}
-        {{- if include "containerRuntime" . }}
-        {{- range include "containerRuntime" .}}
-        - name: {{ .name }}-sock
-          hostPath:
-            path: {{ .runtimeSocket }}
-        - name: {{ .name }}-runc
-          hostPath:
-            path: {{ .runtimeRunc }}
-        {{- end}}
+        {{- if include "containerVolumes" . }}
+        {{- include "containerVolumes" . | nindent 8 }}
         {{- end }}
         # The Gremlin daemon communicates with Gremlin sidecars via its state directory.
         # This should be shared with the Kubernetes host

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -251,3 +251,17 @@ ssl:
   # sets the SSL_CERT_DIR environment variable on the both agents. Unlike ssl.certFile, this value accepts only a
   # path to an existing directory on the Kubernetes nodes. This value is ignored when blank or absent.
   certDir:
+
+containerDrivers:
+  docker-runc:
+    runtimeSocket: "/var/run/docker.sock"
+    runtimeRunc: "/run/docker/runtime-runc/moby"
+    name: "docker"
+  containerd-runc:
+    runtimeSocket: "/run/containerd/containerd.sock"
+    runtimeRunc: "/run/containerd/runc/k8s.io"
+    name: "containerd"
+  crio-runc:
+    runtimeSocket: "/run/crio/crio.sock"
+    runtimeRunc: "/run/runc"
+    name: "crio"

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -267,3 +267,6 @@ containerDrivers:
     runtimeSocket: "/run/crio/crio.sock"
     runtimeRunc: "/run/runc"
     name: "crio"
+  docker:
+    runtimeSocket: "/var/run/docker.sock"
+    name: "docker"


### PR DESCRIPTION
**Background**
Currently installation required customers be intimately familiar with their container runtime
powering their K8s clusters and select this correctly at installation time.

This causes friction for customers who are either unfamiliar (for organizational or security
reasons) or have have nodes with differing drivers

**Change**
Provide a new `any` option for container drivers which mounts sockets for all supported
container drivers

Note: if nodes have multiple container drivers (uncommon) this may lead to the gremlin
agent selecting the wrong driver.  This is on par with the current experience and thus is
considered acceptable