### PR TITLE
allow default seccomp profile to fix seccomp+PSP installs

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.4.4
+version: 0.4.5
 description: The Gremlin Inc client application
 appVersion: "2.16.2"
 apiVersion: v1

--- a/gremlin/templates/gremlin-psp.yaml
+++ b/gremlin/templates/gremlin-psp.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if or .Values.gremlin.apparmor .Values.gremlin.podSecurity.seccomp.enabled }}
   annotations:
     {{- if .Values.gremlin.podSecurity.seccomp.enabled }}
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: {{ join "," .Values.gremlin.podSecurity.seccomp.profile | quote }}
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: {{ concat (list .Values.gremlin.podSecurity.seccomp.profile) (list "runtime/default") | join "," | quote }}
     seccomp.security.alpha.kubernetes.io/defaultProfileName: "runtime/default"
     {{- end }}
     {{- if .Values.gremlin.apparmor }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -209,7 +209,7 @@ gremlin:
       # gremlin.podSecurity.seccomp.profile -
       # Describes the name of the seccomp profile to use
       #
-      # NOTE: When this values is `localhost/gremlin`, Gremlin will create it's own custom seccomp profile
+      # NOTE: When this value is `localhost/gremlin`, Gremlin will create its own custom seccomp profile
       profile: localhost/gremlin
       # gremlin.podSecurity.seccomp.root
       # The absolute path pointing to the seccomp profile root on cluster nodes


### PR DESCRIPTION
## Background

* When `seccomp` and `podSecurityPolicy` flags are both enabled, Gremlin fails to install because the `initContainer` responsible for setting up the seccomp policy, is constrained to using only the policy it is trying to set up, producing a chicken and egg scenario.

## Change

* Add `runtime/default` (already advertised as the `defaultProfileName` in our PSP) to the list of `allowedProfileNames`, which enables our `initContainer` to assume it so it can set up the `localhost/gremlin` profile assumed by our main `gremlin` container.

## Testing

* Local testing shows success with a PSP enabled cluster

```shell
minikube start \
     --extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy \
     --addons=pod-security-policy \
     --kubernetes-version=v1.19.1

helm install gremlin ./gremlin \
     --namespace gremlin \
     --set      gremlin.hostPID=true \
     --set      gremlin.container.driver=any \
     --set      gremlin.podSecurity.podSecurityPolicy.create=true \
     --set      gremlin.podSecurity.seccomp.enabled=true \
     --set      gremlin.secret.teamID=$GREMLIN_TEAM_ID \
     --set      gremlin.secret.teamSecret=$GREMLIN_TEAM_SECRET \
     --set      gremlin.secret.clusterID=$GREMLIN_CLUSTER_ID \
     --set      gremlin.secret.managed=true \
     --set      gremlin.secret.type=secret \
     --set      gremlin.secret.clusterID=test
```