### PR TITLE
add-affinity-nodeselector-tolerations-to-chao

### DIFF
--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -22,9 +22,12 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullSecret`                 | Pull secret for a private registry for the `chao` container    | `""` (When empty, no authentication is used)                                |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
-| `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
-| `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
-| `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |                                                                    |
+| `nodeSelector`                         | Map of node labels for pod assignment for the `gremlin` container | `{}`                                                                        |
+| `tolerations`                          | List of node taints to tolerate for the `gremlin` container    | `[]`                                                                        |
+| `affinity`                             | Map of node/pod affinities for the `gremlin` container         | `{}`                                                                        |
+| `chao.nodeSelector`                    | Map of node labels for pod assignment for the `chao` container | `{}`                                                                        |
+| `chao.tolerations`                     | List of node taints to tolerate for the `chao` container       | `[]`                                                                        |
+| `chao.affinity`                        | Map of node/pod affinities for the `chao` container            | `{}`                                                                        |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.installApparmorProfile`       | Have Gremlin install their own [Apparmor Profile](agent_apparmor.profile) (NOTE: `gremlin.apparmor` overrides this) | `false` |
 | `gremlin.container.driver`             | Specifies which container driver with which to run Gremlin. [See example][driverexample] | `docker` | 

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -25,14 +25,14 @@ spec:
         app.kubernetes.io/version: "1"
     spec:
       serviceAccountName: chao
-      {{- if .Values.affinity }}
-      affinity: {{ toYaml .Values.affinity | trimSuffix "\n" | indent 8 }}
+      {{- if .Values.chao.affinity }}
+      affinity: {{ toYaml .Values.chao.affinity | trimSuffix "\n" | indent 8 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.nodeSelector | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.chao.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.chao.nodeSelector | trimSuffix "\n" | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations: {{ toYaml .Values.tolerations | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.chao.tolerations }}
+      tolerations: {{ toYaml .Values.chao.tolerations | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       {{- if .Values.chaoimage.pullSecret }}
       imagePullSecrets:

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -25,6 +25,15 @@ spec:
         app.kubernetes.io/version: "1"
     spec:
       serviceAccountName: chao
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | trimSuffix "\n" | indent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | trimSuffix "\n" | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{ toYaml .Values.tolerations | trimSuffix "\n" | nindent 8 }}
+      {{- end }}
       {{- if .Values.chaoimage.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.chaoimage.pullSecret }}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       serviceAccountName: chao
       {{- if .Values.chao.affinity }}
-      affinity: {{ toYaml .Values.chao.affinity | trimSuffix "\n" | indent 8 }}
+      affinity: {{ toYaml .Values.chao.affinity | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       {{- if .Values.chao.nodeSelector }}
       nodeSelector: {{ toYaml .Values.chao.nodeSelector | trimSuffix "\n" | nindent 8 }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       serviceAccountName: gremlin
       {{- if .Values.affinity }}
-      affinity: {{ toYaml .Values.affinity | trimSuffix "\n" | indent 8 }}
+      affinity: {{ toYaml .Values.affinity | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | trimSuffix "\n" | nindent 8 }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -253,6 +253,14 @@ gremlin:
     # api.gremlin.com. This value is ignored when blank or absent.
     url:
 
+chao:
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
 ssl:
   # ssl.certFile -
   # Add a certificate file to Gremlin's set of certificate authorities. This argument expects a file containing the


### PR DESCRIPTION
Introduce `affinity`, `nodeSelector`, and `tolerations` to the Chao deployment chart.  See https://gremlininc.slack.com/archives/C010HA9NQK1/p1633649317296600 for more details.
