### PR TITLE
Hack to handle GKE COS Containerd

### DIFF
--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -142,6 +142,18 @@ Create a computed value for the intended Gremlin secret type which can either be
 {{- end -}}
 {{- end -}}
 
+{{- /* GKE Container Optimized OS with Containerd cannot */ -}}
+{{- /* mount the state/logs volumes, so detect that here */ -}}
+{{- define "gkeCOSContainerd" -}}
+{{- $output := false }}
+{{- range $index, $node := (lookup "v1" "Node" "" "").items -}}
+  {{- $gkeRuntime := index $node.metadata.labels "cloud.google.com/gke-container-runtime" -}}
+  {{- $gkeOS := index $node.metadata.labels "cloud.google.com/gke-os-distribution" -}}
+  {{- $output = (or $output (and (eq $gkeRuntime "containerd") (eq $gkeOS "cos"))) -}}
+{{- end -}}
+{{ $output }}
+{{- end -}}
+
 {{- define "pspApiVersion" -}}
 {{- if .Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}
 {{- "policy/v1" -}}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -126,12 +126,14 @@ spec:
             value: {{ .Values.ssl.certDir }}
           {{- end }}
         volumeMounts:
+          {{- if not (include "gkeCOSContainerd" .) }}
           - name: gremlin-state
             mountPath: /var/lib/gremlin
             readOnly: false
           - name: gremlin-logs
             mountPath: /var/log/gremlin
             readOnly: false
+          {{- end }}
           - name: cgroup-root
             mountPath: /sys/fs/cgroup
             readOnly: true


### PR DESCRIPTION
**Background**
We've run into some problems with GKE's COS with the containerd runtime.
This manifests as a permissions issue when attempting to use runc to
initiate a side car container which mounts the `state` and `logs` paths
(which are themselves hostmounted paths) from the daemonset

**Change**
Don't mount these paths as hostmounts

Gremlin agent will create these inside the daemonset's pod's chroot and
then mount those inside of the sidecar which does work properly.  The
only downside is we lose debuggability when the ds pod restarts as the
folders aren't hostmounted.  While this is undesirable it is acceptable
to work around the GKE limitations

In order to support this the Helm chart will identify if it's installing
on to a GKE COS containerd environment before removing these hostmounts

NOTE: Helm doesn't run the lookup command when running a `template`
command or a `--dry-run` and you will not get the hostmounts removed
when debugging that way.  Instead you have to do the full installation
to test