### PR TITLE
cgroupv2 support: allow /sys/fs/cgroup to be writable

### DIFF
--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -134,7 +134,7 @@ spec:
             readOnly: false
           - name: cgroup-root
             mountPath: /sys/fs/cgroup
-            readOnly: true
+            readOnly: false
           - name: shutdown-trigger
             mountPath: /sysrq
           {{- if include "containerMounts" . }}


### PR DESCRIPTION
## Background

Gremlin needs write access to `/sys/fs/cgroup` so that we can place Gremlin attack sidecars into the cgroup of our targets.