### PR TITLE
enable gremlin process collection by default

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.5.0
+version: 0.6.0
 description: The Gremlin Inc client application
 appVersion: "2.26.0"
 apiVersion: v1

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -111,10 +111,8 @@ spec:
             value: {{ .Values.gremlin.client.tags }}
           - name: GREMLIN_DOCKER_IMAGE
             value: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-          {{- if .Values.gremlin.collect.processes }}
           - name: GREMLIN_COLLECT_PROCESSES
-            value: "true"
-          {{- end }}
+            value: {{ .Values.gremlin.collect.processes | quote }}
           - name: GREMLIN_SERVICE_URL
             value: {{ include "gremlinServiceUrl" . }}
           {{- if .Values.gremlin.proxy.url }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -43,7 +43,7 @@ gremlin:
   collect:
     # gremlin.collect.processes -
     # Specifies whether Gremlin should collect process information
-    processes: false
+    processes: true
 
   # gremlin.hostPID -
   # This must be true for Gremlin container drivers: `docker-runc`, `crio-runc` and `containerd-runc`. It is also


### PR DESCRIPTION
This has been defaulted to `true` in `gremlin 2.25.0`. This helm chart change is made to match this.