### PR TITLE
SeLinuxOption config

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.7.0
+version: 0.8.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -35,7 +35,8 @@ their default values. See values.yaml for all available options.
 | `gremlin.serviceAccount.create`        | Specifies whether Gremlin's kubernetes service account should be created by this helm chart | `true` | 
 | `gremlin.podSecurity.allowPrivilegeEscalation` | Allows Gremlin containers privilege escalation powers  | `false` | 
 | `gremlin.podSecurity.capabilities`     | Specifies which Linux capabilities should be granted to Gremlin| `[KILL, NET_ADMIN, SYS_BOOT, SYS_TIME, SYS_ADMIN, SYS_PTRACE, SETFCAP, AUDIT_WRITE, MKNOD]` |
-| `gremlin.podSecurity.seLinuxOptions`   | Specifies SELinux options to apply to the Gremlin Daemonset container securityContext| `""` |
+| `gremlin.podSecurity.useSELinuxOptions`| Set `seLinuxOptions` on Gremlin Daemonset containers. For modifying what's set see: `gremlin.podSecurity.seLinuxOptions` | `false` |
+| `gremlin.podSecurity.seLinuxOptions`   | Specifies SELinux options to apply to the Gremlin Daemonset container securityContext (read more [here](https://github.com/gremlin/selinux-policies)) | `{type: gremlin.profile}` |
 | `gremlin.podSecurity.readOnlyRootFilesystem` | Forces the Gremlin Daemonset containers to run with a read-only root filesystem | `false` |
 | `gremlin.podSecurity.supplementalGroups.rule` | Specifies the Linux groups the Gremlin Daemonset containers should run as | `RunAsAny` | 
 | `gremlin.podSecurity.fsGroup.rule`     | Specifies the Linux groups applied to mounted volumes          | `RunAsAny` | 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -35,6 +35,7 @@ their default values. See values.yaml for all available options.
 | `gremlin.serviceAccount.create`        | Specifies whether Gremlin's kubernetes service account should be created by this helm chart | `true` | 
 | `gremlin.podSecurity.allowPrivilegeEscalation` | Allows Gremlin containers privilege escalation powers  | `false` | 
 | `gremlin.podSecurity.capabilities`     | Specifies which Linux capabilities should be granted to Gremlin| `[KILL, NET_ADMIN, SYS_BOOT, SYS_TIME, SYS_ADMIN, SYS_PTRACE, SETFCAP, AUDIT_WRITE, MKNOD]` |
+| `gremlin.podSecurity.seLinuxOptions`   | Specifies SELinux options to apply to the Gremlin Daemonset container securityContext| `""` |
 | `gremlin.podSecurity.readOnlyRootFilesystem` | Forces the Gremlin Daemonset containers to run with a read-only root filesystem | `false` |
 | `gremlin.podSecurity.supplementalGroups.rule` | Specifies the Linux groups the Gremlin Daemonset containers should run as | `RunAsAny` | 
 | `gremlin.podSecurity.fsGroup.rule`     | Specifies the Linux groups applied to mounted volumes          | `RunAsAny` | 

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
         securityContext:
           capabilities:
             add: {{ toYaml .Values.gremlin.podSecurity.capabilities | nindent 14 }}
-          {{- if .Values.gremlin.podSecurity.seLinuxOptions }}
+          {{- if .Values.gremlin.podSecurity.useSELinuxOptions }}
           seLinuxOptions: {{ toYaml .Values.gremlin.podSecurity.seLinuxOptions | nindent 12 }}
           {{- end }}
         env:

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -79,6 +79,9 @@ spec:
         securityContext:
           capabilities:
             add: {{ toYaml .Values.gremlin.podSecurity.capabilities | nindent 14 }}
+          {{- if .Values.gremlin.podSecurity.seLinuxOptions }}
+          seLinuxOptions: {{ toYaml .Values.gremlin.podSecurity.seLinuxOptions | nindent 12 }}
+          {{- end }}
         env:
           - name: GREMLIN_TEAM_ID
             {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -149,6 +149,10 @@ gremlin:
                     #   Not actively used by Gremlin but requested by sidecars
                     #   This capability will be removed in a later release
 
+    # gremlin.podSecurity.seLinuxOptions -
+    # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext
+    seLinuxOptions:
+
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem
     readOnlyRootFilesystem: false

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -149,9 +149,14 @@ gremlin:
                     #   Not actively used by Gremlin but requested by sidecars
                     #   This capability will be removed in a later release
 
+    # gremlin.podSecurity.useSELinuxOptions
+    useSELinuxOptions: false
+
     # gremlin.podSecurity.seLinuxOptions -
-    # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext
+    # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext if gremlin.podSecurity.useSELinuxOptions is set to true
+    # For installation of the Gremlin profile see: https://github.com/gremlin/selinux-policies
     seLinuxOptions:
+      type: gremlin.process
 
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem


### PR DESCRIPTION
**Background**
See: https://github.com/gremlin/helm/pull/77 for broader context

The goal here is to give customers the ability to override the `seLinuxOptions` on the
Gremlin daemonset, while still preserving the default (recommended) configuration.

**Changes**
 1. bump the version
 2. add `gremlin.podSecurity.seLinuxOptions` value for overriding `seLinuxOptions` on the Daemonset (defaulting to our [`gremlin.profile`](https://github.com/gremlin/selinux-policies/))
 3. add `gremlin.podSecurity.useSELinuxOptions` value for enabling/disabling adding the `seLinuxOptions`

NOTE: Setting only `gremlin.podSecurity.useSELinuxOptions` will use our default options.  If the customer wants to modify those options they need to use both `gremlin.podSecurity.useSELinuxOptions` and `gremlin.podSecurity.seLinuxOptions`