### PR TITLE
[Gremlin Agent] Provide SeLinuxOptions for overriding

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.7.0
+version: 0.8.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -35,7 +35,7 @@ their default values. See values.yaml for all available options.
 | `gremlin.serviceAccount.create`        | Specifies whether Gremlin's kubernetes service account should be created by this helm chart | `true` | 
 | `gremlin.podSecurity.allowPrivilegeEscalation` | Allows Gremlin containers privilege escalation powers  | `false` | 
 | `gremlin.podSecurity.capabilities`     | Specifies which Linux capabilities should be granted to Gremlin| `[KILL, NET_ADMIN, SYS_BOOT, SYS_TIME, SYS_ADMIN, SYS_PTRACE, SETFCAP, AUDIT_WRITE, MKNOD]` |
-| `gremlin.podSecurity.seLinuxOptions`   | Specifies SELinux options to apply to the Gremlin Daemonset container securityContext| `""` |
+| `gremlin.podSecurity.seLinuxOptions`   | Specifies SELinux options to apply to the Gremlin Daemonset container securityContext. WARNING: This option should be enabled with caution as it is likely to break the GremlinAgent or your Kubernetes installation. Gremlin recommends users instead install a custom SELinux policy that provides integration with the labels already defined on the target system so that paths do not need to be relabeled. See https://github.com/gremlin/selinux-policies | `""` |
 | `gremlin.podSecurity.readOnlyRootFilesystem` | Forces the Gremlin Daemonset containers to run with a read-only root filesystem | `false` |
 | `gremlin.podSecurity.supplementalGroups.rule` | Specifies the Linux groups the Gremlin Daemonset containers should run as | `RunAsAny` | 
 | `gremlin.podSecurity.fsGroup.rule`     | Specifies the Linux groups applied to mounted volumes          | `RunAsAny` | 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -35,6 +35,7 @@ their default values. See values.yaml for all available options.
 | `gremlin.serviceAccount.create`        | Specifies whether Gremlin's kubernetes service account should be created by this helm chart | `true` | 
 | `gremlin.podSecurity.allowPrivilegeEscalation` | Allows Gremlin containers privilege escalation powers  | `false` | 
 | `gremlin.podSecurity.capabilities`     | Specifies which Linux capabilities should be granted to Gremlin| `[KILL, NET_ADMIN, SYS_BOOT, SYS_TIME, SYS_ADMIN, SYS_PTRACE, SETFCAP, AUDIT_WRITE, MKNOD]` |
+| `gremlin.podSecurity.seLinuxOptions`   | Specifies SELinux options to apply to the Gremlin Daemonset container securityContext| `""` |
 | `gremlin.podSecurity.readOnlyRootFilesystem` | Forces the Gremlin Daemonset containers to run with a read-only root filesystem | `false` |
 | `gremlin.podSecurity.supplementalGroups.rule` | Specifies the Linux groups the Gremlin Daemonset containers should run as | `RunAsAny` | 
 | `gremlin.podSecurity.fsGroup.rule`     | Specifies the Linux groups applied to mounted volumes          | `RunAsAny` | 

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -79,6 +79,9 @@ spec:
         securityContext:
           capabilities:
             add: {{ toYaml .Values.gremlin.podSecurity.capabilities | nindent 14 }}
+          {{- if .Values.gremlin.podSecurity.seLinuxOptions }}
+          seLinuxOptions: {{ toYaml .Values.gremlin.podSecurity.seLinuxOptions | nindent 12 }}
+          {{- end }}
         env:
           - name: GREMLIN_TEAM_ID
             {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -149,6 +149,10 @@ gremlin:
                     #   Not actively used by Gremlin but requested by sidecars
                     #   This capability will be removed in a later release
 
+    # gremlin.podSecurity.seLinuxOptions -
+    # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext
+    seLinuxOptions:
+
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem
     readOnlyRootFilesystem: false

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -150,7 +150,12 @@ gremlin:
                     #   This capability will be removed in a later release
 
     # gremlin.podSecurity.seLinuxOptions -
-    # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext
+    # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext. 
+    #
+    # WARNING: This option should be enabled with caution as it will relabel paths on the host filesystem according
+    # to gremlin.podSecurity.seLinuxOptions, which includes container runtime socket files and container state directories.
+    # Gremlin recommends users instead install a custom SELinux policy that provides integration with the labels already
+    # defined on the target system so that paths do not need to be relabeled. See https://github.com/gremlin/selinux-policies
     seLinuxOptions:
 
     # gremlin.podSecurity.readOnlyRootFilesystem -


### PR DESCRIPTION
Allows the user to specify SELinux labels and types to apply to the Gremlin Daemonset.
Also bumps chart to `0.8.0`.

NOTE: These are exceptionally dangerous options and customers using them may negatively impact their cluster or Gremlin deployment in ways that Gremlin cannot support