### PR TITLE
make gremlin.container.driver=any the new default

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.9.0
+version: 0.10.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -96,7 +96,7 @@ gremlin:
     #                                           /run/crio/crio.sock, /run/runc,
     #                                           /run/containers/containers.sock, /run/containerd/runc/k8s.io]
     #
-    driver: docker
+    driver: any
 
   cgroup:
     # gremlin.cgroup.root -


### PR DESCRIPTION
## Background

* when set `gremlin.container.driver=any` will attempt to mount all possible container driver paths, delegating to `gremlin` to pick the runtime. This option has served as the easiest way to get Gremlin up and running on containerized systems because you don't need to know or muck with container driver details.

## Change

* make `any` the new default