### PR TITLE
[Labels] Add Overridable Labels

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.9.0
+version: 0.9.1
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -25,9 +25,11 @@ their default values. See values.yaml for all available options.
 | `nodeSelector`                         | Map of node labels for pod assignment for the `gremlin` container | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate for the `gremlin` container    | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities for the `gremlin` container         | `{}`                                                                        |
+| `chao.podLabels`                       | Kubernetes labels applied to the chao deployment and it's Pods | `{}`                                                                        |
 | `chao.nodeSelector`                    | Map of node labels for pod assignment for the `chao` container | `{}`                                                                        |
 | `chao.tolerations`                     | List of node taints to tolerate for the `chao` container       | `[]`                                                                        |
 | `chao.affinity`                        | Map of node/pod affinities for the `chao` container            | `{}`                                                                        |
+| `gremlin.podLabels`           | Kubernetes labels applied to the Gremlin Agent's DaemonSet and it's pods| `{}`                                                                        |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.installApparmorProfile`       | Have Gremlin install their own [Apparmor Profile](agent_apparmor.profile) (NOTE: `gremlin.apparmor` overrides this) | `false` |
 | `gremlin.container.driver`             | Specifies which container driver with which to run Gremlin. [See example][driverexample] | `docker` | 

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/name: chao
     helm.sh/chart: {{ include "gremlin.chart" . }}
     app.kubernetes.io/version: "1"
+    {{- if .Values.chao.podLabels }}
+    {{- toYaml .Values.chao.podLabels | nindent 4 }}
+    {{- end }}
   name: chao
   namespace: {{ .Release.Namespace }}
 spec:
@@ -27,6 +30,9 @@ spec:
         app.kubernetes.io/name: chao
         helm.sh/chart: {{ include "gremlin.chart" . }}
         app.kubernetes.io/version: "1"
+        {{- if .Values.chao.podLabels }}
+        {{- toYaml .Values.chao.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: chao
       {{- if .Values.chao.affinity }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     version: v1
+    {{- if .Values.gremlin.podLabels }}
+    {{- toYaml .Values.gremlin.podLabels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -25,6 +28,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         version: v1
+        {{- if .Values.gremlin.podLabels }}
+        {{- toYaml .Values.gremlin.podLabels | nindent 8 }}
+        {{- end }}
       {{- if (or .Values.gremlin.podSecurity.seccomp.enabled (or .Values.gremlin.apparmor .Values.gremlin.installApparmorProfile) ) }}
       annotations:
         {{- if .Values.gremlin.apparmor }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -32,6 +32,10 @@ gremlin:
     rollingUpdate:
       maxUnavailable: 1
 
+  # gremlin.podLabels -
+  # Kubernetes labels applied to the Gremlin Agent's DaemonSet and it's pods
+  podLabels: {}
+
   # gremlin.apparmor -
   # Gremlin assumes apparmor is not enabled by default and so it will not specify any apparmor profile to use
   # You may need to provide a specific profile if your environment requires it.
@@ -284,6 +288,8 @@ chao:
   tolerations: []
 
   affinity: {}
+
+  podLabels: {}
 
 ssl:
   # ssl.certFile -


### PR DESCRIPTION
**Background**
We want to provide some convenience around users being able to add labels to the deployed Gremlin Pods

**Change**
Add labels to `values.yaml` and then apply them to the associated Deployment/DaemonSet

I've applied them to both the Pod and the managing K8s primitive, but I can be convinced to only put them on the Pod