### PR TITLE
Clarify the capabilities for cert expiry

### DIFF
--- a/gremlin/agent_apparmor.profile
+++ b/gremlin/agent_apparmor.profile
@@ -56,7 +56,7 @@ profile gremlin-agent flags=(attach_disconnected,mediate_deleted) {
   capability setgid,
   capability chown,
 
-  # Needed for Gremlin Service Discovery and executing a certificate expiry attack
+  # Needed for Gremlin Service Discovery and executing a certificate expiry experiment
   capability dac_read_search,
   capability sys_ptrace,
 

--- a/gremlin/agent_apparmor.profile
+++ b/gremlin/agent_apparmor.profile
@@ -56,7 +56,7 @@ profile gremlin-agent flags=(attach_disconnected,mediate_deleted) {
   capability setgid,
   capability chown,
 
-  # Needed for Gremlin Service Discovery
+  # Needed for Gremlin Service Discovery and executing a certificate expiry attack
   capability dac_read_search,
   capability sys_ptrace,
 


### PR DESCRIPTION
## Background

If a cert expiry experiment is configured to target a CIDR, the linux capabilities `dac_read_search` and `sys_ptrace` are required to discover the active connections that match that CIDR.

## Changes

Update a comment to clarify that we need those capabilities for service discovery (in `gremlind`) but also certificate expiry experiments (in `gremlin`). 