### PR TITLE
Add DNS collection configuration

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.12.1
+version: 0.12.2
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -130,6 +130,8 @@ spec:
             value: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           - name: GREMLIN_COLLECT_PROCESSES
             value: {{ .Values.gremlin.collect.processes | quote }}
+          - name: GREMLIN_COLLECT_DNS
+            value: {{ .Values.gremlin.collect.dns | quote }}
           - name: GREMLIN_SERVICE_URL
             value: {{ include "gremlinServiceUrl" . }}
           {{- if .Values.gremlin.proxy.url }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -52,6 +52,9 @@ gremlin:
     # gremlin.collect.processes -
     # Specifies whether Gremlin should collect process information
     processes: true
+    # gremlin.collect.dns -
+    # Specifies whether Gremlin should collect DNS call information
+    dns: false
 
   # gremlin.hostPID -
   # This must be true for Gremlin container drivers: `docker-runc`, `crio-runc` and `containerd-runc`. It is also


### PR DESCRIPTION
Added option to enable new DNS collection feature. By default it will be off.
New lines were added in the same place the current process collection config exists.

```
zach@DESKTOP-GIU9M5L:/mnt/c/Users/Zach/My Documents/Workspace/helm$ helm template gremlin ./gremlin --set gremlin.collect.dns=true --set gremlin.secret.type=secret --set gremlin.secret.teamSecret=secret --set gremlin.secret.managed=true --set gremlin.secret.teamID=test --set gremlin.secret.clusterID=cluseter
...
# Source: gremlin/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: gremlin
  namespace: default
  labels:
    app.kubernetes.io/name: gremlin
    helm.sh/chart: gremlin-0.12.1
    app.kubernetes.io/instance: gremlin
    app.kubernetes.io/managed-by: Helm
    version: v1
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: gremlin
  updateStrategy:
    rollingUpdate:
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/name: gremlin
        helm.sh/chart: gremlin-0.12.1
        app.kubernetes.io/instance: gremlin
        app.kubernetes.io/managed-by: Helm
        version: v1
    spec:
      serviceAccountName: gremlin
      hostPID: false
      hostNetwork: false
      containers:
      - name: gremlin
        image: gremlin/gremlin:latest
        args: [ "daemon" ]
        imagePullPolicy: Always
        securityContext:
          capabilities:
            add:
              - KILL
              - NET_ADMIN
              - SYS_BOOT
              - SYS_TIME
              - DAC_READ_SEARCH
              - SYS_ADMIN
              - SYS_PTRACE
              - SETFCAP
              - AUDIT_WRITE
              - MKNOD
              - SYS_CHROOT
              - NET_RAW
        env:
          - name: GREMLIN_TEAM_ID
            valueFrom:
              secretKeyRef:
                name:  gremlin-secret
                key: GREMLIN_TEAM_ID
          - name: GREMLIN_TEAM_SECRET
            valueFrom:
              secretKeyRef:
                name: gremlin-secret
                key: GREMLIN_TEAM_SECRET
          - name: GREMLIN_IDENTIFIER
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
          - name: GREMLIN_CLIENT_TAGS
            value:
          - name: GREMLIN_DOCKER_IMAGE
            value: gremlin/gremlin:latest
          - name: GREMLIN_COLLECT_PROCESSES
            value: "true"
          - name: GREMLIN_COLLECT_DNS
            value: "true"
          - name: GREMLIN_SERVICE_URL
            value: https://api.gremlin.com/v1
...
```

https://gremlininc.atlassian.net/browse/EN-6119