### PR TITLE
remove /proc/sysrq-trigger mount, default host namespaces true

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.16.0
+version: 0.17.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com
@@ -7,4 +7,4 @@ maintainers:
 - name: Gremlin Development
   email: dev@gremlin.com
 annotations:
-  minimumAppVersion: 2.29.0
+  minimumAppVersion: 2.44.0

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -64,8 +64,8 @@ their default values. See values.yaml for all available options.
 | `gremlin.secret.key`                   | Contents of the private key. Required if using managed secrets of `type=certificate`  | `""`                                                 |
 | `gremlin.secret.teamSecret`            | Gremlin's team secret. Required if using managed secrets of `type=secret`  | `""`                                                            |
 | `gremlin.resources`                    | Set resource requests and limits                               | `{}`                                                                        |
-| `gremlin.hostPID`                      | Enable host-level process killing                              | `false`                                                                     |
-| `gremlin.hostNetwork`                  | Enable host-level network attacks                              | `false`                                                                     |
+| `gremlin.hostPID`                      | Enable host-level process killing                              | `true`                                                                     |
+| `gremlin.hostNetwork`                  | Enable host-level network attacks                              | `true`                                                                     |
 | `gremlin.priorityClassName`            | The priority class to use for the agent DaemonSet              | `""`                                                                     |
 | `gremlin.client.tags`                  | Comma-separated list of custom tags to assign to this client   | `""`                                                                        |
 | `gremlin.proxy.url`                    | Specifies the http proxy the agent should use to communicate with api.gremlin.com. |  `""` (ignored) |                                       |

--- a/gremlin/agent_apparmor.profile
+++ b/gremlin/agent_apparmor.profile
@@ -33,7 +33,6 @@ profile gremlin-agent flags=(attach_disconnected,mediate_deleted) {
 
 
   # Attack capabilities
-  /proc/sysrq-trigger w,
   /sys/fs/cgroup/** rw,
   /proc/** rl,
   # In order to join target container network space
@@ -92,7 +91,7 @@ profile gremlin-agent flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
   deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
-  deny @{PROC}/sysrq-trigger klx,
+  deny @{PROC}/sysrq-trigger wklx,
   deny @{PROC}/mem wklx,
   deny @{PROC}/kmem wklx,
   deny @{PROC}/kcore wklx,

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -163,8 +163,6 @@ spec:
           - name: cgroup-root
             mountPath: /sys/fs/cgroup
             readOnly: false
-          - name: shutdown-trigger
-            mountPath: /sysrq
           {{- if include "containerMounts" . }}
           {{- include "containerMounts" . | nindent 10 }}
           {{- end }}
@@ -195,9 +193,6 @@ spec:
         - name: gremlin-logs
           hostPath:
             path: /var/log/gremlin
-        - name: shutdown-trigger
-          hostPath:
-            path: /proc/sysrq-trigger
         {{- if (eq (include "gremlin.secretType" .) "certificate") }}
         - name: gremlin-cert
           secret:

--- a/gremlin/templates/gremlin-psp.yaml
+++ b/gremlin/templates/gremlin-psp.yaml
@@ -32,8 +32,6 @@ spec:
       readOnly: false
     - pathPrefix: /var/log/gremlin
       readOnly: false
-    - pathPrefix: /proc/sysrq-trigger
-      readOnly: false
     - pathPrefix: {{ .Values.gremlin.cgroup.root }}
       readOnly: true
     {{- if include "containerMountsPSP" . }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -57,17 +57,15 @@ gremlin:
     dns: true
 
   # gremlin.hostPID -
-  # This must be true for Gremlin container drivers: `docker-runc`, `crio-runc` and `containerd-runc`. It is also
-  #   required for any Gremlin installation that wishes to carry out Process Killer attacks at the host-level
-  #   (e.g. any root-owned process)
+  # This must be true for all Gremlin container drivers exept for the legacy `docker` driver. It is also required
+  #   for any Gremlin installation that wishes to carry out Process Killer or attacks at the host-level
   #
-  # NOTE: this is disabled by default to maintain behavior of previous versions
-  hostPID: false
+  hostPID: true
 
   # gremlin.hostNetwork -
-  # This must be true for any Gremlin installation that wishes to carry out network attacks at the host-level
-  #   (e.g. impact network traffic to all host processes and containers)
-  hostNetwork: false
+  # This must be true for any Gremlin installation that wishes to carry out network attacks at the host-level. It
+  #   is also required for Gremlin's dependency discovery features.
+  hostNetwork: true
 
   # gremlin.installApparmorProfile -
   # This controls if gremlin installs it's own apparmor profile.  This is only necessary if you're running apparmor


### PR DESCRIPTION
## Background

* Gremlin currently allows a host shutdown in two different ways: using a `/proc/sysrq-trigger`, and issuing a shutdown from the host's `PID` namespace. Only the latter [is documented](https://www.gremlin.com/docs/fault-injection-experiments-shutdown), and the former performs a non-graceful shutdown (which isn't documented in Gremlin).
* At the same time, `hostPID=true` has become a requirement for all container drivers except for the legacy `docker` driver. It makes sense to flip this to `true` to minimize issues at install time resulting from incorrect arguments.
  * `hostNetwork` is in the same situation, though unrelated to shutdown attacks.

## Change

* Remove mount of `/proc/sysrq-trigger` which disables this functionality in Gremlin
* default `hostPID=true` to enable host attacks without sysrq
* while we're at it, default `hostNetwork=true` as well, since it is required for reliability management features.