### PR TITLE
Fix string type values

### DIFF
--- a/gremlin-integrations/templates/_helpers.tpl
+++ b/gremlin-integrations/templates/_helpers.tpl
@@ -67,9 +67,9 @@ In later versions of this chart, we will remove the use of the fallback value of
 */}}
 {{- define "gremlin.secretName" -}}
 {{- if .Values.gremlin.secret.managed -}}
-{{- default .Values.gremlin.secret.name "gremlin-integrations-secret" -}}
+{{- default "gremlin-integrations-secret" .Values.gremlin.secret.name -}}
 {{- else -}}
-{{- default .Values.gremlin.secret.name "gremlin-integrations-team-cert" -}}
+{{- default "gremlin-integrations-team-cert" .Values.gremlin.secret.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.12.2
+version: 0.12.3
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -37,9 +37,9 @@ In later versions of this chart, we will remove the use of the fallback value of
 */}}
 {{- define "gremlin.secretName" -}}
 {{- if .Values.gremlin.secret.managed -}}
-{{- default .Values.gremlin.secret.name "gremlin-secret" -}}
+{{- default "gremlin-secret" .Values.gremlin.secret.name -}}
 {{- else -}}
-{{- default .Values.gremlin.secret.name "gremlin-team-cert" -}}
+{{- default "gremlin-team-cert" .Values.gremlin.secret.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -39,7 +39,7 @@ In later versions of this chart, we will remove the use of the fallback value of
 {{- if .Values.gremlin.secret.managed -}}
 {{- default .Values.gremlin.secret.name "gremlin-secret" -}}
 {{- else -}}
-{{- .Values.gremlin.secret.name "gremlin-team-cert" -}}
+{{- default .Values.gremlin.secret.name "gremlin-team-cert" -}}
 {{- end -}}
 {{- end -}}
 

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -258,25 +258,25 @@ gremlin:
     type: certificate
     managed: false
     # team identifier (e.g. 11111111-1111-1111-1111-111111111111)
-    teamID:
+    teamID: ""
     # string uniquely identifying this kubernetes cluster in Gremlin (e.g. my-cluster)
-    clusterID:
+    clusterID: ""
 
     ## Certificate auth requires: `certificate` and `key`
     # team certificate (e.g. -----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----)
-    certificate:
+    certificate: ""
     # team private key (e.g. -----BEGIN EC PRIVATE KEY-----...-----END EC PRIVATE KEY-----)
-    key:
+    key: ""
 
     ## Secret auth requires: `teamSecret`
     # team secret (e.g. 00000000-0000-0000-0000-000000000000)
-    teamSecret:
+    teamSecret: ""
 
   proxy:
     # gremlin.proxy.url -
     # Specifies the http proxy that the Gremlin Agent and Gremlin Kubernetes agent should use to communicate with
     # api.gremlin.com. This value is ignored when blank or absent.
-    url:
+    url: ""
 
   # gremlin.extraEnv -
   # Specify any arbitrary environment variables to pass to the Gremlin Agent daemonset.


### PR DESCRIPTION
There was a bug where helm inaccurately assumed the type of the certificate field
```
Helm upgrade failed for release gremlin/gremlin with chart gremlin@0.12.2: template: gremlin/templates/daemonset.yaml:111:50: executing "gremlin/templates/daemonset.yaml" at <.Values.gremlin.secret.certificate>: wrong type for value; expected string; got interface {}
```

So I set the default in values.yaml to be empty strings

Test:

```
helm template gremlin ./gremlin  --namespace gremlin  --set gremlin.secret.name=gremlin-secret  --set gremlin.secret.type=certificate  --set gremlin.secret.clusterID="cluster-id"  --set gremlin.secret.teamID="team-id"
...
---
# Source: gremlin/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: gremlin
  namespace: gremlin
  labels:
    app.kubernetes.io/name: gremlin
    helm.sh/chart: gremlin-0.12.3
    app.kubernetes.io/instance: gremlin
    app.kubernetes.io/managed-by: Helm
    version: v1
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: gremlin
  updateStrategy:
    rollingUpdate:
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/name: gremlin
        helm.sh/chart: gremlin-0.12.3
        app.kubernetes.io/instance: gremlin
        app.kubernetes.io/managed-by: Helm
        version: v1
    spec:
      serviceAccountName: gremlin
      hostPID: false
      hostNetwork: false
      containers:
      - name: gremlin
        image: gremlin/gremlin:latest
        args: [ "daemon" ]
        imagePullPolicy: Always
        securityContext:
          capabilities:
            add:
              - KILL
              - NET_ADMIN
              - SYS_BOOT
              - SYS_TIME
              - DAC_READ_SEARCH
              - SYS_ADMIN
              - SYS_PTRACE
              - SETFCAP
              - AUDIT_WRITE
              - MKNOD
              - SYS_CHROOT
              - NET_RAW
        env:
          - name: GREMLIN_TEAM_ID
            value: "team-id"
          - name: GREMLIN_TEAM_CERTIFICATE_OR_FILE
            value:
          - name: GREMLIN_TEAM_PRIVATE_KEY_OR_FILE
            value:
          - name: GREMLIN_IDENTIFIER
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
          - name: GREMLIN_CLIENT_TAGS
            value:
          - name: GREMLIN_DOCKER_IMAGE
            value: gremlin/gremlin:latest
          - name: GREMLIN_COLLECT_PROCESSES
            value: "true"
          - name: GREMLIN_COLLECT_DNS
            value: "false"
          - name: GREMLIN_SERVICE_URL
            value: https://api.gremlin.com/v1
        volumeMounts:
          - name: gremlin-state
            mountPath: /var/lib/gremlin
            readOnly: false
          - name: gremlin-logs
            mountPath: /var/log/gremlin
            readOnly: false
          - name: cgroup-root
            mountPath: /sys/fs/cgroup
            readOnly: false
          - name: shutdown-trigger
            mountPath: /sysrq

          - name: containerd-sock
            mountPath: /run/containerd/containerd.sock
            readOnly: true
          - name: containerd-runc
            mountPath: /run/containerd/runc/k8s.io
            readOnly: false
          - name: crio-sock
            mountPath: /run/crio/crio.sock
            readOnly: true
          - name: crio-runc
            mountPath: /run/runc
            readOnly: false
          - name: docker-sock
            mountPath: /var/run/docker.sock
            readOnly: true
          - name: docker-runc
            mountPath: /run/docker/runtime-runc/moby
            readOnly: false
          - name: gremlin-cert
            mountPath: /var/lib/gremlin/cert
            readOnly: true
      volumes:
        - name: cgroup-root
          hostPath:
            path: /sys/fs/cgroup

        - name: containerd-sock
          hostPath:
            path: /run/containerd/containerd.sock
        - name: containerd-runc
          hostPath:
            path: /run/containerd/runc/k8s.io
        - name: crio-sock
          hostPath:
            path: /run/crio/crio.sock
        - name: crio-runc
          hostPath:
            path: /run/runc
        - name: docker-sock
          hostPath:
            path: /var/run/docker.sock
        - name: docker-runc
          hostPath:
            path: /run/docker/runtime-runc/moby
        # The Gremlin daemon communicates with Gremlin sidecars via its state directory.
        # This should be shared with the Kubernetes host
        - name: gremlin-state
          hostPath:
            path: /var/lib/gremlin
        # The Gremlin daemon forwards logs from the Gremlin sidecars to the Gremlin control plane
        # These logs should be shared with the host
        - name: gremlin-logs
          hostPath:
            path: /var/log/gremlin
        - name: shutdown-trigger
          hostPath:
            path: /proc/sysrq-trigger
        - name: gremlin-cert
          secret:
            secretName: gremlin-team-cert
---
# Source: gremlin/templates/chao-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/instance: chao
    app.kubernetes.io/name: chao
    helm.sh/chart: gremlin-0.12.3
    app.kubernetes.io/version: "1"
  name: chao
  namespace: gremlin
spec:
  replicas: 1
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/instance: chao
      app.kubernetes.io/name: chao
      app.kubernetes.io/version: "1"
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: chao
        app.kubernetes.io/name: chao
        helm.sh/chart: gremlin-0.12.3
        app.kubernetes.io/version: "1"
    spec:
      serviceAccountName: chao
      containers:
        - image: gremlin/chao:latest
          env:
            - name: GREMLIN_TEAM_ID
              value: "team-id"
            - name: GREMLIN_CLUSTER_ID
              value: "cluster-id"
          args:
            - "-api_url"
            - "https://api.gremlin.com/v1/kubernetes"
            - "-cert_path"
            - ""
            - "-key_path"
            - ""
          imagePullPolicy: Always
          name: chao
          volumeMounts:
          - name: gremlin-cert
            mountPath: /var/lib/gremlin/cert
            readOnly: true
      volumes:
      - name: gremlin-cert
        secret:
          secretName: gremlin-team-cert
```