### PR TITLE
correctly ref cert paths when gremlin.secret.managed=false

### DIFF
--- a/gremlin-integrations/Chart.yaml
+++ b/gremlin-integrations/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gremlin-integrations/templates/deployment.yaml
+++ b/gremlin-integrations/templates/deployment.yaml
@@ -53,13 +53,14 @@ spec:
                   key: GREMLIN_TEAM_SECRET
           {{- else }}
             - name: GREMLIN_TEAM_CERTIFICATE_OR_FILE
-              {{- if (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
+              {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
+              {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
               value: file:///var/lib/gremlin/cert/gremlin.cert
               {{- else }}
               value: {{ .Values.gremlin.secret.certificate }}
               {{- end }}
             - name: GREMLIN_TEAM_PRIVATE_KEY_OR_FILE
-              {{- if (hasPrefix "-----BEGIN" .Values.gremlin.secret.key) }}
+              {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.key) }}
               value: file:///var/lib/gremlin/cert/gremlin.key
               {{- else }}
               value: {{ .Values.gremlin.secret.key }}

--- a/gremlin-integrations/values.yaml
+++ b/gremlin-integrations/values.yaml
@@ -55,17 +55,17 @@ gremlin:
     type: certificate
     managed: false
     # team identifier (e.g. 11111111-1111-1111-1111-111111111111)
-    teamID:
+    teamID: ""
 
     ## Certificate auth requires: `certificate` and `key`
     # team certificate (e.g. -----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----)
-    certificate:
+    certificate: ""
     # team private key (e.g. -----BEGIN EC PRIVATE KEY-----...-----END EC PRIVATE KEY-----)
-    key:
+    key: ""
 
     ## Secret auth requires: `teamSecret`
     # team secret (e.g. 00000000-0000-0000-0000-000000000000)
-    teamSecret:
+    teamSecret: ""
   allowList: ""
   proxy:
     # gremlin.proxy.url -

--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.12.3
+version: 0.12.4
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -104,13 +104,15 @@ spec:
             - "{{ include "gremlinServiceUrl" . }}/kubernetes"
             {{- if (eq (include "gremlin.secretType" .) "certificate") }}
             - "-cert_path"
-            {{- if (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
+            {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
+            {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
             - "/var/lib/gremlin/cert/gremlin.cert"
             {{- else }}
             - {{ .Values.gremlin.secret.certificate | quote }}
             {{- end }}
             - "-key_path"
-            {{- if (hasPrefix "-----BEGIN" .Values.gremlin.secret.key) }}
+            {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
+            {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.key) }}
             - "/var/lib/gremlin/cert/gremlin.key"
             {{- else }}
             - {{ .Values.gremlin.secret.key | quote }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -108,13 +108,15 @@ spec:
                 key: GREMLIN_TEAM_SECRET
           {{- else }}
           - name: GREMLIN_TEAM_CERTIFICATE_OR_FILE
-            {{- if (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
+            {{- /* If managed outside of this chart, or if the value is a literal, reference the secret as a file */}}
+            {{- if or (not .Values.gremlin.secret.managed)  (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
             value: file:///var/lib/gremlin/cert/gremlin.cert
             {{- else }}
             value: {{ .Values.gremlin.secret.certificate }}
             {{- end }}
           - name: GREMLIN_TEAM_PRIVATE_KEY_OR_FILE
-            {{- if (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
+            {{- /* If managed outside of this chart, or if the value is a literal, reference the secret as a file */}}
+            {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
             value: file:///var/lib/gremlin/cert/gremlin.key
             {{- else }}
             value: {{ .Values.gremlin.secret.key }}


### PR DESCRIPTION
## Background

* A recent change broke secret references for both secret auth and certificate auth.
  * Regression introduced in #88
  * Fix for secret auth introduced in #92

## Change

* Account for `.Values.gremlin.secret.managed` when populating values for `GREMLIN_TEAM_CERTIFICATE_OR_FILE` and `GREMLIN_TEAM_PRIVATE_KEY_OR_FILE`

## Testing

**Setup**

Create Secret

```shell
kubectl create secret generic my-gremlin-secret \
    --namespace gremlin \
    --from-literal=GREMLIN_TEAM_ID=$GREMLIN_TEAM_ID \
    --from-file=gremlin.cert=/path/to/cert.pem \
    --from-file=gremlin.key=/path/to/key.pem \
    --from-literal=GREMLIN_CLUSTER_ID=my-cluster-id
```

Install Gremlin

```shell
helm install gremlin gremlin/gremlin \
    --namespace gremlin \
    --set gremlin.secret.name=my-gremlin-secret \
    --set gremlin.secret.type=certificate
```

**Without fix**

Gremlin installs but then crashes due to empty values for cert and key variables

**With fix**

Gremlin installs and runs without errror