### PR TITLE
Switch default values of gremlin.collect.processes/dns

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.12.4
+version: 0.12.5
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -51,10 +51,10 @@ gremlin:
   collect:
     # gremlin.collect.processes -
     # Specifies whether Gremlin should collect process information
-    processes: true
+    processes: false
     # gremlin.collect.dns -
     # Specifies whether Gremlin should collect DNS call information
-    dns: false
+    dns: true
 
   # gremlin.hostPID -
   # This must be true for Gremlin container drivers: `docker-runc`, `crio-runc` and `containerd-runc`. It is also


### PR DESCRIPTION
We're going to be enabling DNS collection by default soon, so staging this PR for when the agent change is ready to release.