### PR TITLE
Add cap SYS_RESOURCE for Process Exhaustion container attacks

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.12.5
+version: 0.12.6
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -135,6 +135,7 @@ gremlin:
       - SYS_BOOT        # Required to run Shutdown attacks
       - SYS_TIME        # Required to run Time Travel attacks
       - DAC_READ_SEARCH # Required to run Certificate Expiry attacks, and dependency discovery features
+      - SYS_RESOURCE    # Required to run Process Exhaustion attacks
 
       - SYS_ADMIN       # Required by container drivers: docker-runc, crio-runc, containerd-runc
                         #   to run attacks against running containers
@@ -157,9 +158,6 @@ gremlin:
       - NET_RAW         # Required by container drivers: docker-runc, crio-runc, containerd-runc
                         #   Not actively used by Gremlin but requested by sidecars
                         #   This capability will be removed in a later release
-
-      - SYS_RESOURCE    # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                        #   to run Process Exhaustion experiments
 
     # gremlin.podSecurity.seLinuxOptions -
     # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext.

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -135,7 +135,7 @@ gremlin:
       - SYS_BOOT        # Required to run Shutdown attacks
       - SYS_TIME        # Required to run Time Travel attacks
       - DAC_READ_SEARCH # Required to run Certificate Expiry attacks, and dependency discovery features
-      - SYS_RESOURCE    # Required to run Process Exhaustion attacks
+      - SYS_RESOURCE    # Required to run Process Exhaustion attacks against containers
 
       - SYS_ADMIN       # Required by container drivers: docker-runc, crio-runc, containerd-runc
                         #   to run attacks against running containers

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -158,6 +158,9 @@ gremlin:
                         #   Not actively used by Gremlin but requested by sidecars
                         #   This capability will be removed in a later release
 
+      - SYS_RESOURCE    # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                        #   to run Process Exhaustion experiments
+
     # gremlin.podSecurity.seLinuxOptions -
     # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext.
     #


### PR DESCRIPTION
## Background

We need the linux capability `SYS_RESOURCE` for process exhaustion attacks to safeguard against lingering defunct processes after an out of memory error.

## Changes

Add the linux capability `SYS_RESOURCE` for updating the OOM score of the `gremlin` process.