### PR TITLE
Add capability for process exhaustion

### DIFF
--- a/gremlin/agent_apparmor.profile
+++ b/gremlin/agent_apparmor.profile
@@ -60,6 +60,9 @@ profile gremlin-agent flags=(attach_disconnected,mediate_deleted) {
   capability dac_read_search,
   capability sys_ptrace,
 
+  # Needed for Gremlin Process Exhaustion
+  capability sys_resource
+
   # General deny
   deny /bin/** wl,
   deny /boot/** wl,


### PR DESCRIPTION
Add linux capability `sys_resource` for process exhaustion to change the oom score of the `gremlin` process.