### PR TITLE
cleanup: remove invalid scc field, clarify SELinux constraint

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.13.0
+version: 0.14.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -83,6 +83,7 @@ spec:
         resources: {{ toYaml .Values.gremlin.resources | nindent 10 }}
         {{- end }}
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.gremlin.podSecurity.allowPrivilegeEscalation }}
           capabilities:
             add: {{ toYaml .Values.gremlin.podSecurity.capabilities | nindent 14 }}
           {{- if .Values.gremlin.podSecurity.seLinuxOptions }}

--- a/gremlin/templates/gremlin-scc.yaml
+++ b/gremlin/templates/gremlin-scc.yaml
@@ -17,7 +17,6 @@ allowPrivilegeEscalation: {{ .Values.gremlin.podSecurity.allowPrivilegeEscalatio
 allowPrivilegedContainer: {{ .Values.gremlin.podSecurity.privileged }}
 allowedCapabilities: {{ toYaml .Values.gremlin.podSecurity.capabilities | nindent 2 }}
 defaultAddCapabilities: null
-fsGroup: {{ toYaml .Values.gremlin.podSecurity.fsGroup | nindent 2 }}
 groups: []
 priority: null
 readOnlyRootFilesystem: {{ .Values.gremlin.podSecurity.readOnlyRootFilesystem }}
@@ -29,6 +28,5 @@ seccompProfiles:
   {{- if .Values.gremlin.podSecurity.seccomp.enabled }}
   - {{ .Values.gremlin.podSecurity.seccomp.profile | quote }}
   {{- end }}
-supplementalGroups: {{ toYaml .Values.gremlin.podSecurity.supplementalGroups | nindent 2 }}
 volumes: {{ toYaml .Values.gremlin.podSecurity.volumes | nindent 2 }}
 {{ end }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -230,7 +230,9 @@ gremlin:
       seLinuxContext:
         type: MustRunAs
         seLinuxOptions:
-          type: gremlin.process
+          #  gremlin.podSecurity.securityContextConstraints.seLinuxContext.type -
+          #  Specifies the SELinux process label gremlin should run under. OpenShift uses the CRI-O container runtime, which deploys any container with hostPID=true as `spc_t`. Any other value is ignored.
+          type: spc_t
           level: s0-s0:c0.c1023
       # gremlin.podSecurity.securityContextConstraints.runAsUser -
       # Specifies the Linux user the Gremlin Daemonset containers should run as


### PR DESCRIPTION
## Background

* scc fields fsGroup and supplementalGroups are exposed in Kubernetes PodSecurityPolicies, not SecurityContextConstraints. You can see warnings for these fields when installing Gremlin into OpenShift 4.14.
* Gremlin sets an seLinux.type value in its scc implying Gremlin will run as `gremlin.process`. In reality, CRI-O does not allow running containers that have `hostPID=true` under any SELinux label other than spc_t`. See https://github.com/cri-o/cri-o/blob/main/server/container_create_linux.go#L306 and https://github.com/cri-o/cri-o/issues/5501.

## Change

* remove `fsGroup` and `supplementalGroups` from gremlin-scc.yaml (they are invalid)
* rename seLinux.type under the scc section to use `spc_t` instead of `gremlin.process`
* explicitly pass `allowPrivilegeEscalation` to our daemonset, already set in `.Values.gremlin.podSecurity.allowPrivilegeEscalation`

## Testing

* Installed Gremlin on OpenShift 4.14