### PR TITLE
Grant access to K8s zone and region labels

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.14.0
+version: 0.15.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/gremlin-service-account.yaml
+++ b/gremlin/templates/gremlin-service-account.yaml
@@ -9,12 +9,11 @@ metadata:
     {{- with .Values.gremlin.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-{{ if .Values.gremlin.podSecurity.podSecurityPolicy.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gremlin-watcher
+  name: gremlin-daemon-watcher
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -31,7 +30,8 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gremlin-watcher
+  name: gremlin-daemon-watcher
+{{ if .Values.gremlin.podSecurity.podSecurityPolicy.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/gremlin/templates/gremlin-service-account.yaml
+++ b/gremlin/templates/gremlin-service-account.yaml
@@ -13,7 +13,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gremlin-daemon-watcher
+  name: gremlin-node-metadata-reader
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -30,7 +30,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gremlin-daemon-watcher
+  name: gremlin-node-metadata-reader
 {{ if .Values.gremlin.podSecurity.podSecurityPolicy.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/gremlin/templates/gremlin-service-account.yaml
+++ b/gremlin/templates/gremlin-service-account.yaml
@@ -12,6 +12,28 @@ metadata:
 {{ if .Values.gremlin.podSecurity.podSecurityPolicy.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gremlin-watcher
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gremlin
+subjects:
+  - kind: ServiceAccount
+    name: gremlin
+    namespace: gremlin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gremlin-watcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp:gremlin


### PR DESCRIPTION
## Background

Gremlin daemon needs permissions to fetch the zone and region from the K8s node's topology labels in case they are available in on-prem clusters or clusters not hosted in AWS, GCP or Azure.

## Changes

Add a cluster role binding to grant access to the cluster's node labels.

## Testing

- Verified the gremlin's tags `zone` and `region` are populated with the node's `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels in an Openshift cluster after installing this chart
- Verified that the daemon logs a permission warning about checking the helm chart after installing an older version of this chart