### PR TITLE
openshift: annotate require-scc on daemonset to force our scc

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.15.0
+version: 0.16.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -31,7 +31,6 @@ spec:
         {{- if .Values.gremlin.podLabels }}
         {{- toYaml .Values.gremlin.podLabels | nindent 8 }}
         {{- end }}
-      {{- if (or .Values.gremlin.podSecurity.seccomp.enabled (or .Values.gremlin.apparmor .Values.gremlin.installApparmorProfile) ) }}
       annotations:
         {{- if .Values.gremlin.apparmor }}
         container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: {{ .Values.gremlin.apparmor }}
@@ -41,7 +40,9 @@ spec:
         {{- if .Values.gremlin.podSecurity.seccomp.enabled }}
         container.seccomp.security.alpha.kubernetes.io/{{ .Chart.Name }}: {{ .Values.gremlin.podSecurity.seccomp.profile }}
         {{- end }}
-      {{- end }}
+        {{- if .Values.gremlin.podSecurity.securityContextConstraints.create }}
+        openshift.io/required-scc: "gremlin"
+        {{- end }}
     spec:
       serviceAccountName: gremlin
       {{- if .Values.affinity }}


### PR DESCRIPTION
## Background

* When `gremlin.podSecurity.createSecurityContextConstraints.create=true` we create a `gremlin` scc, but do not force the pods of the gremlin daemonset to run with it
* Forcing pods to use this scc requires an annotation: https://docs.openshift.com/container-platform/4.14/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth

## Change

* set `openshift.io/require-scc: gremlin` when scc creation is enabled