### PR TITLE
reference privileged value in daemonset.yaml to honor user input

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.17.0
+version: 0.17.1
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -84,6 +84,7 @@ spec:
         resources: {{ toYaml .Values.gremlin.resources | nindent 10 }}
         {{- end }}
         securityContext:
+          privileged: {{ .Values.gremlin.podSecurity.privileged }}
           allowPrivilegeEscalation: {{ .Values.gremlin.podSecurity.allowPrivilegeEscalation }}
           capabilities:
             add: {{ toYaml .Values.gremlin.podSecurity.capabilities | nindent 14 }}


### PR DESCRIPTION
## Background

* We expose `gremlin.podSecurity.privileged` in our values.yaml, but never use it

## Change

* Set the daemonset's `privileged` value according to values