### PR TITLE
update description of CAP_NET_RAW capability requirement

### DIFF
--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -166,9 +166,9 @@ gremlin:
       - SYS_CHROOT      # Required by container drivers: docker-runc, crio-runc, containerd-runc
                         #   to create and enter new namespaces for Gremlin attack sidecars
 
-      - NET_RAW         # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                        #   Not actively used by Gremlin but requested by sidecars
-                        #   This capability will be removed in a later release
+      - NET_RAW         # Required when gremlin.collect.dns=true, provides Gremlin the ability to
+                        #   look at DNS traffic for dependency discovery. 
+                        #   See https://www.gremlin.com/blog/how-dependency-discovery-works-in-gremlin
 
     # gremlin.podSecurity.seLinuxOptions -
     # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext.


### PR DESCRIPTION
This capability was required for Gremlin versions older than 2.18.2, because our `runc` drivers would run sidecars with a "capabilities-add" request that was unaccompanied by a "drop-all" request and `CAP_NET_RAW` was among those requested by default.

Incidentally, we've depended on `CAP_NET_RAW` since [2.40.1][1] for another purpose: dependency discovery (when `gremlin.collect.dns=true`). Update the description for when and why this capability is needed.

[1]: https://www.gremlin.com/docs/release-notes-linux#2-40-1