### PR TITLE
[Chao] Add clientId value

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.18.0
+version: 0.19.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -25,6 +25,7 @@ their default values. See values.yaml for all available options.
 | `nodeSelector`                         | Map of node labels for pod assignment for the `gremlin` container | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate for the `gremlin` container    | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities for the `gremlin` container         | `{}`                                                                        |
+| `chao.clientId`                        | An identifier for this specific client.  Leaving this blank will generate a random one | `""`                                                                          |
 | `chao.podLabels`                       | Kubernetes labels applied to the chao deployment and it's Pods | `{}`                                                                        |
 | `chao.priorityClassName`               | The name of the priority class to use for the Chao deployment  | `""`                                                                        |
 | `chao.nodeSelector`                    | Map of node labels for pod assignment for the `chao` container | `{}`                                                                        |

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -102,22 +102,26 @@ spec:
           args:
             - "-api_url"
             - "{{ include "gremlinServiceUrl" . }}/kubernetes"
-            {{- if (eq (include "gremlin.secretType" .) "certificate") }}
+{{- if (eq (include "gremlin.secretType" .) "certificate") }}
             - "-cert_path"
             {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
-            {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
+  {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
             - "/var/lib/gremlin/cert/gremlin.cert"
-            {{- else }}
+  {{- else }}
             - {{ .Values.gremlin.secret.certificate | quote }}
-            {{- end }}
+  {{- end }}
             - "-key_path"
-            {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
-            {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.key) }}
+  {{- /* If we aren't managing this secret and a teamID was supplied, assume teamID is not in the external secret */}}
+  {{- if or (not .Values.gremlin.secret.managed) (hasPrefix "-----BEGIN" .Values.gremlin.secret.key) }}
             - "/var/lib/gremlin/cert/gremlin.key"
-            {{- else }}
+  {{- else }}
             - {{ .Values.gremlin.secret.key | quote }}
-            {{- end }}
-            {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .Values.chao.clientId }}
+            - "-client_id"
+            - {{ .Value.chao.clientId }}
+{{- end }}
           imagePullPolicy: {{ .Values.chaoimage.pullPolicy }}
           name: chao
 {{- if (or ((eq (include "gremlin.secretType" .) "certificate")) .Values.ssl.certFile) }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -312,6 +312,10 @@ chao:
   # The name of the priority class to use for the Chao deployment
   priorityClassName: ""
 
+  # chao.clientId -
+  # the client identifier used to communicate with the control plane
+  clientId: ""
+
   nodeSelector: {}
 
   tolerations: []


### PR DESCRIPTION
**Background**
We typically attempt to generate a stable clientId based on gremlin namespace creation time.  For some customers this is not sustainable and they want to set this explicitly