### PR TITLE
Add namespaces argument for chao

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.18.0
+version: 0.18.1
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -32,6 +32,7 @@ their default values. See values.yaml for all available options.
 | `chao.affinity`                        | Map of node/pod affinities for the `chao` container            | `{}`                                                                        |
 | `chao.create`                          | Enable kubernetes targeting by installing k8s client           |  true                                                                       |
 | `chao.extraEnv`                        | Specify any arbitrary environment variables to pass to the Chao deployment. | `[]`                                                           |
+| `chao.namespaces`                      | List of namespaces for Gremlin to watch for attacking          | `[]`
 | `gremlin.podLabels`           | Kubernetes labels applied to the Gremlin Agent's DaemonSet and it's pods| `{}`                                                                        |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.installApparmorProfile`       | Have Gremlin install their own [Apparmor Profile](agent_apparmor.profile) (NOTE: `gremlin.apparmor` overrides this) | `false` |

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -118,6 +118,10 @@ spec:
             - {{ .Values.gremlin.secret.key | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.chao.namespaces }}
+            - "-namespaces"
+            - "{{ join "," .Values.chao.namespaces }}"
+            {{- end}}
           imagePullPolicy: {{ .Values.chaoimage.pullPolicy }}
           name: chao
 {{- if (or ((eq (include "gremlin.secretType" .) "certificate")) .Values.ssl.certFile) }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -331,6 +331,10 @@ chao:
   # Specify any arbitrary environment variables to pass to the Chao deployment.
   extraEnv: []
 
+  # chao.namespaces
+  # list of namespaces for Gremlin to watch for attacking
+  namespaces: []
+
 ssl:
   # ssl.certFile -
   # Add a certificate file to Gremlin's set of certificate authorities. This argument expects a file containing the


### PR DESCRIPTION
The chao agent can accept an argument to limit the targeting of namespaces watched and uploaded. This change exposes that argument more easily in the helm chart.

```
helm template gremlin ./gremlin --namespace gremlin --set gremlin.hostPID=true --set gremlin.hostNetwork=true --set gremlin.collect.processes=true --set gremlin.container.driver=docker-runc --set gremlin.secret.managed=true --set gremlin.secret.type=secret --set gremlin.secret.teamID=a --set gremlin.secret.teamSecret=b --set gremlin.serviceUrl=c --set image.tag=$(git rev-parse HEAD) --debug --set chao.namespaces[0]=x --set chao.namespaces[1]=y --set chao.namespaces[2]=z
......
# Source: gremlin/templates/chao-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/instance: chao
    app.kubernetes.io/name: chao
    helm.sh/chart: gremlin-0.18.0
    app.kubernetes.io/version: "1"
  name: chao
  namespace: gremlin
spec:
  replicas: 1
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/instance: chao
      app.kubernetes.io/name: chao
      app.kubernetes.io/version: "1"
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: chao
        app.kubernetes.io/name: chao
        helm.sh/chart: gremlin-0.18.0
        app.kubernetes.io/version: "1"
    spec:
      serviceAccountName: chao
      containers:
        - image: gremlin/chao:latest
          env:
            - name: GREMLIN_TEAM_ID
              valueFrom:
                secretKeyRef:
                  name:  gremlin-secret
                  key: GREMLIN_TEAM_ID
            - name: GREMLIN_CLUSTER_ID
              valueFrom:
                secretKeyRef:
                  name:  gremlin-secret
                  key: GREMLIN_CLUSTER_ID
            - name: GREMLIN_TEAM_SECRET
              valueFrom:
                secretKeyRef:
                  name: gremlin-secret
                  key: GREMLIN_TEAM_SECRET
          args:
            - "-api_url"
            - "c/kubernetes"
            - "-namespaces"
            - "x,y,z"
          imagePullPolicy: Always
          name: chao
      volumes:
      - name: gremlin-cert
        secret:
          secretName: gremlin-secret
```