### PR TITLE
[Rollout] Add permissions for Argo Rollouts

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.18.1
+version: 0.19.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/chao-service-account.yaml
+++ b/gremlin/templates/chao-service-account.yaml
@@ -27,6 +27,9 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["get", "list", "watch"]    
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Background

Add permissions so that Argo rollouts can be targeted (agent changes are still needed).

## Changes

Added RBAC rules for `argoproj.io` API group to allow `get`, `list`, and `watch` verbs on `rollouts` resource.

## Testing

