### PR TITLE
Update secret.yaml to include parentheses

### DIFF
--- a/gremlin/templates/secret.yaml
+++ b/gremlin/templates/secret.yaml
@@ -15,7 +15,7 @@ stringData:
   GREMLIN_CLUSTER_ID: {{ (default .Values.gremlin.clusterID .Values.gremlin.secret.clusterID | required "required: .Values.gremlin.secret.clusterID") | toString }}
   GREMLIN_TEAM_ID: {{ (default .Values.gremlin.teamID .Values.gremlin.secret.teamID | required "required: .Values.gremlin.secret.teamID") | toString }}
 {{- if (eq (include "gremlin.secretType" .) "secret") }}
-  GREMLIN_TEAM_SECRET: {{ .Values.gremlin.secret.teamSecret | required "required: .Values.gremlin.secret.teamSecret" |  toString }}
+  GREMLIN_TEAM_SECRET: {{ (.Values.gremlin.secret.teamSecret | required "required: .Values.gremlin.secret.teamSecret") |  toString }}
 {{- else if (eq (include "gremlin.secretType" .) "certificate") }}
 {{- if (hasPrefix "-----BEGIN" .Values.gremlin.secret.certificate) }}
   GREMLIN_TEAM_CERTIFICATE_OR_FILE: file:///var/lib/gremlin/cert/gremlin.cert

--- a/gremlin/templates/secret.yaml
+++ b/gremlin/templates/secret.yaml
@@ -12,8 +12,8 @@ metadata:
     version: v1
 type: kubernetes.io/Opaque
 stringData:
-  GREMLIN_CLUSTER_ID: {{ default .Values.gremlin.clusterID .Values.gremlin.secret.clusterID | required "required: .Values.gremlin.secret.clusterID" | toString }}
-  GREMLIN_TEAM_ID: {{ default .Values.gremlin.teamID .Values.gremlin.secret.teamID | required "required: .Values.gremlin.secret.teamID" | toString }}
+  GREMLIN_CLUSTER_ID: {{ (default .Values.gremlin.clusterID .Values.gremlin.secret.clusterID | required "required: .Values.gremlin.secret.clusterID") | toString }}
+  GREMLIN_TEAM_ID: {{ (default .Values.gremlin.teamID .Values.gremlin.secret.teamID | required "required: .Values.gremlin.secret.teamID") | toString }}
 {{- if (eq (include "gremlin.secretType" .) "secret") }}
   GREMLIN_TEAM_SECRET: {{ .Values.gremlin.secret.teamSecret | required "required: .Values.gremlin.secret.teamSecret" |  toString }}
 {{- else if (eq (include "gremlin.secretType" .) "certificate") }}


### PR DESCRIPTION
Add parentheses so that 'default' and 'required' are evaluated before the result is passed to the 'toString' function (this will prevent numeric team IDs from throwing an error when installed according to our docs)