### PR TITLE
feat: Store all non-execution data in-memory

### DIFF
--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -156,6 +156,9 @@ spec:
           - name: gremlin-state
             mountPath: /var/lib/gremlin
             readOnly: false
+          - name: gremlin-executions
+            mountPath: /var/lib/gremlin/executions
+            readOnly: false
           - name: gremlin-logs
             mountPath: /var/log/gremlin
             readOnly: false
@@ -185,8 +188,11 @@ spec:
         # The Gremlin daemon communicates with Gremlin sidecars via its state directory.
         # This should be shared with the Kubernetes host
         - name: gremlin-state
+          emptyDir:
+            medium: Memory
+        - name: gremlin-executions
           hostPath:
-            path: /var/lib/gremlin
+            path: /var/lib/gremlin/executions
         # The Gremlin daemon forwards logs from the Gremlin sidecars to the Gremlin control plane
         # These logs should be shared with the host
         - name: gremlin-logs


### PR DESCRIPTION
Currently credentials and other gremlin state data are stored to a host path. The only data that really needs to persist a container restart is the execution-related data used to allow the agent to rollback an attack even after an agent restart.

By moving around changing some mounts, we can store all except the execution data in-memory. Execution data will still be stored to disk.