### PR TITLE
seLinuxOptions: clarify correct usage, add callout to bottlerocket

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.19.0
+version: 0.19.1
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -170,11 +170,13 @@ gremlin:
     # gremlin.podSecurity.seLinuxOptions -
     # Specifies SELinux options to apply to the Gremlin Daemonset container securityContext.
     #
-    # WARNING: This option should be enabled with caution as it will relabel paths on the host filesystem according
-    # to gremlin.podSecurity.seLinuxOptions, which includes container runtime socket files and container state directories.
-    # Gremlin recommends users instead install a custom SELinux policy that provides integration with the labels already
-    # defined on the target system so that paths do not need to be relabeled. See https://github.com/gremlin/selinux-policies
+    # WARNING: Setting anything other than seLinuxOptions.type should be done with caution as these options may relabel paths on the host filesystem,
+    # including container runtime socket files and container state directories. Only the `type` value is recommended to be set here, such as in the
+    # case of using BottleRocket, this should be set to `type: super_t`.
     seLinuxOptions:
+      # gremlin.podSecurity.seLinuxOptions.type -
+      # Specifies the process label gremlind processes should run under. When running BottleRocket for example, this should be set to `super_t`
+      # type: super_t
 
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem


### PR DESCRIPTION
As it turns out, the `seLinuxOptions.type` does not incur relabeling of mounted files, and it should be the only field we need (at least in currently known cases)