### PR TITLE
feat: Add unittests for Chao in the gremlin chart

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,12 @@
+name: Unit tests
+
+on: pull_request
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: d3adb5/helm-unittest-action@v2
+        with:
+          helm-version: v3.17.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 .iml
+
+**/tests/__snapshot__/

--- a/gremlin/.helmignore
+++ b/gremlin/.helmignore
@@ -20,3 +20,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Helm unit tests which shouldn't be included in the package
+tests/

--- a/gremlin/templates/NOTES.txt
+++ b/gremlin/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "gremlin.validateValues" $}}

--- a/gremlin/templates/_validation.tpl
+++ b/gremlin/templates/_validation.tpl
@@ -1,0 +1,21 @@
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "gremlin.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "gremlin.validateValues.secret" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "%s\n" $message | fail -}}
+{{- else -}}
+{{- printf "Validation succeeded." -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "gremlin.validateValues.secret" -}}
+{{- if and .Values.gremlin.secret.managed (eq .Values.gremlin.secret.type "certificate") (or (not .Values.gremlin.secret.certificate) (not .Values.gremlin.secret.key)) -}}
+- When using a managed certificate, both the certificate and key must be provided.
+{{- end -}}
+{{- end -}}

--- a/gremlin/tests/chao_deployment_test.yaml
+++ b/gremlin/tests/chao_deployment_test.yaml
@@ -79,7 +79,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.name
           value: "gremlin-secret"
-  - it: should mount the certificate volumes when a certificate is specified
+  - it: should mount the gremlin-team-cert volume when a certificate is used and secret is not managed
     set:
       gremlin.secret.managed: false
       gremlin.secret.type: certificate
@@ -105,7 +105,7 @@ tests:
             name: gremlin-cert
             secret:
               secretName: gremlin-team-cert
-  - it: should mount the certificate volumes when a certificate is specified
+  - it: should mount the certificate volumes when the secret is managed and a certificate is specified
     set:
       gremlin.secret.managed: true
       gremlin.secret.type: certificate

--- a/gremlin/tests/chao_deployment_test.yaml
+++ b/gremlin/tests/chao_deployment_test.yaml
@@ -133,7 +133,7 @@ tests:
             name: gremlin-cert
             secret:
               secretName: gremlin-secret
-  - it: should set the secret name to gremlin-secret when not managed and no custom secret name is set
+  - it: should set the secret name to gremlin-team-cert when not managed and no custom secret name is set
     asserts:
       - equal:
           path: spec.template.spec.volumes[0].secret.secretName

--- a/gremlin/tests/chao_deployment_test.yaml
+++ b/gremlin/tests/chao_deployment_test.yaml
@@ -1,0 +1,155 @@
+suite: test deployment
+templates:
+  - chao-deployment.yaml
+tests:
+  - it: should create a deployment
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: "chao"
+  - it: should allow specifying a custom registry and tag
+    set:
+      chaoimage.tag: "0.0.1"
+      chaoimage.repository: "docker.io/my/custom/repository"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/my/custom/repository:0.0.1"
+  - it: should allow specifying a custom pull secret
+    set:
+      chaoimage.pullSecret: "my-pull-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: "my-pull-secret"
+  - it: should specify a team ID in the environment when not managed by a secret
+    set:
+      gremlin.secret.managed: false
+      gremlin.teamID: "01719721-1be8-4315-b197-211be83315a4"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: "GREMLIN_TEAM_ID"
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "01719721-1be8-4315-b197-211be83315a4"
+  - it: should populate the team ID from the managed secret when managed secret is set
+    set:
+      gremlin.secret.managed: true
+      gremlin.secret.teamID: "01719721-1be8-4315-b197-211be83315a4"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: "GREMLIN_TEAM_ID"
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: "gremlin-secret"
+  - it: should specify a cluster ID in the environment when not managed by a secret
+    set:
+      gremlin.secret.managed: false
+      gremlin.clusterID: "my-cluster"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: "GREMLIN_CLUSTER_ID"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "my-cluster"
+  - it: should populate the cluster ID from the managed secret when managed secret is set
+    set:
+      gremlin.secret.managed: true
+      gremlin.secret.clusterID: "my-cluster"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: "GREMLIN_CLUSTER_ID"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: "gremlin-secret"
+  - it: should set GREMLIN_TEAM_SECRET when secret type is set to secret and secret is managed
+    set:
+      gremlin.secret.managed: true
+      gremlin.secret.type: secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: "GREMLIN_TEAM_SECRET"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.name
+          value: "gremlin-secret"
+  - it: should mount the certificate volumes when a certificate is specified
+    set:
+      gremlin.secret.managed: false
+      gremlin.secret.type: certificate
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -api_url
+            - https://api.gremlin.com/v1/kubernetes
+            - -cert_path
+            - /var/lib/gremlin/cert/gremlin.cert
+            - -key_path
+            - /var/lib/gremlin/cert/gremlin.key
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+          value:
+            name: gremlin-cert
+            mountPath: /var/lib/gremlin/cert
+            readOnly: true
+      - equal:
+          path: spec.template.spec.volumes[0]
+          value:
+            name: gremlin-cert
+            secret:
+              secretName: gremlin-team-cert
+  - it: should mount the certificate volumes when a certificate is specified
+    set:
+      gremlin.secret.managed: true
+      gremlin.secret.type: certificate
+      gremlin.secret.certificate: "-----BEGIN CERTIFICATE-----\ndummy-cert\n-----END CERTIFICATE-----"
+      gremlin.secret.key: "-----BEGIN PRIVATE KEY-----\ndummy-key\n-----END PRIVATE KEY-----"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -api_url
+            - https://api.gremlin.com/v1/kubernetes
+            - -cert_path
+            - /var/lib/gremlin/cert/gremlin.cert
+            - -key_path
+            - /var/lib/gremlin/cert/gremlin.key
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+          value:
+            name: gremlin-cert
+            mountPath: /var/lib/gremlin/cert
+            readOnly: true
+      - equal:
+          path: spec.template.spec.volumes[0]
+          value:
+            name: gremlin-cert
+            secret:
+              secretName: gremlin-secret
+  - it: should set the secret name to gremlin-secret when not managed and no custom secret name is set
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: "gremlin-team-cert"
+  - it: should set the secret name to the gremlin-secret when managed and no custom secret name is set
+    set:
+      gremlin.secret.managed: true
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: "gremlin-secret"
+  - it: should set the secret name to the custom secret name when set
+    set:
+      gremlin.secret.managed: true
+      gremlin.secret.name: "my-custom-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: "my-custom-secret"

--- a/gremlin/tests/notes_test.yaml
+++ b/gremlin/tests/notes_test.yaml
@@ -1,0 +1,11 @@
+suite: test deployment
+templates:
+  - NOTES.txt
+tests:
+  - it: should fail if a managed secret is used and no key or certificate is passed
+    set:
+      gremlin.secret.managed: true
+      gremlin.secret.type: certificate
+    asserts:
+      - failedTemplate:
+          errorPattern: "When using a managed certificate, both the certificate and key must be provided."


### PR DESCRIPTION
To help gain confidence that future refactors will not completely break the chart, we should add unit testing to catch problems before they're merged.