### PR TITLE
hotfix: declare emptyDir in OpenShift SCC

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.20.1
+version: 0.20.2
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -161,7 +161,8 @@ gremlin:
     volumes:
       - configMap   # Required when the Gremlin Daemonset installs a seccomp profile (see gremlin.podSecurity.seccomp)
       - secret      # Required to store and load secret information like certificates that authenticate Gremlin
-      - hostPath    # Required by Gremlin to store attack logs (/var/log/gremlin) and attack state (/var/lib/gremlin)
+      - hostPath    # Required by Gremlin to store attack logs (/var/log/gremlin) and attack state (/var/lib/gremlin/executions)
+      - emptyDir    # Required by Gremlin to store transient files, such as `/var/lib/gremlin/.credentials`
 
     podSecurityPolicy:
       # gremlin.podSecurity.podSecurityPolicy.create -


### PR DESCRIPTION
Without this, OpenShift will not authorize the gremlin DaemonSet to run.

```
Error creating: pods "gremlin-" is forbidden: unable to validate against any security context constraint: spec.volumes[2]: Invalid value: "emptyDir": emptyDir volumes are not allowed to be used
```