### PR TITLE
[Gremlin] Add Namespace to Secret template

### DIFF
--- a/gremlin/templates/secret.yaml
+++ b/gremlin/templates/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "gremlin.secretName" . }}
+  namespace: {{ .Release.Namespace  }}
   labels:
     app.kubernetes.io/name: {{ include "gremlin.name" . }}
     helm.sh/chart: {{ include "gremlin.chart" . }}


### PR DESCRIPTION
**Background**
When you run the `helm install` command you can supply a namespace which populates this field.  It also causes these templates to be inserted into that namespace.  However, if you run other commands (eg. helm template) then the namespace field only get populated on those templates which make explicit references to it

It looks like secret.yaml is the only one which does not have this field set

**Change**
Add this field