### PR TITLE
Make dnsPolicy configurable

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.20.2
+version: 0.21.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -65,6 +65,7 @@ their default values. See values.yaml for all available options.
 | `gremlin.secret.key`                   | Contents of the private key. Required if using managed secrets of `type=certificate`  | `""`                                                                                        |
 | `gremlin.secret.teamSecret`            | Gremlin's team secret. Required if using managed secrets of `type=secret`  | `""`                                                                                        |
 | `gremlin.resources`                    | Set resource requests and limits                               | `{}`                                                                                        |
+| `gremlin.dnsPolicy`                    | The DNS policy to use for the Gremlin DaemonSet                | `ClusterFirstWithHostNet`                                                                   |
 | `gremlin.hostPID`                      | Enable host-level process killing                              | `true`                                                                                      |
 | `gremlin.hostNetwork`                  | Enable host-level network attacks                              | `true`                                                                                      |
 | `gremlin.priorityClassName`            | The priority class to use for the agent DaemonSet              | `""`                                                                                        |

--- a/gremlin/templates/_validation.tpl
+++ b/gremlin/templates/_validation.tpl
@@ -3,8 +3,8 @@ Compile all warnings into a single message, and call fail.
 */}}
 {{- define "gremlin.validateValues" -}}
 {{- $messages := list -}}
-{{- $messages := append $messages (include "gremlin.validateValues.secret" .) -}}
-{{- $messages := without $messages "" -}}
+{{- $messages = append $messages (include "gremlin.validateValues.secret" .) -}}
+{{- $messages = without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
 {{- if $message -}}

--- a/gremlin/templates/_validation.tpl
+++ b/gremlin/templates/_validation.tpl
@@ -3,12 +3,12 @@ Compile all warnings into a single message, and call fail.
 */}}
 {{- define "gremlin.validateValues" -}}
 {{- $messages := list -}}
-{{- $messages = append $messages (include "gremlin.validateValues.secret" .) -}}
-{{- $messages = without $messages "" -}}
+{{- $messages := append $messages (include "gremlin.validateValues.secret" .) -}}
+{{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
 {{- if $message -}}
-{{-   printf "%s\n" $message | fail -}}
+{{- printf "%s" $message | fail -}}
 {{- else -}}
 {{- printf "Validation succeeded." -}}
 {{- end -}}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -54,6 +54,7 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | trimSuffix "\n" | nindent 8 }}
       {{- end }}
+      dnsPolicy: {{ .Values.gremlin.dnsPolicy }}
       hostPID: {{ .Values.gremlin.hostPID }}
       hostNetwork: {{ .Values.gremlin.hostNetwork }}
       {{- if .Values.image.pullSecret }}

--- a/gremlin/templates/gremlin-psp.yaml
+++ b/gremlin/templates/gremlin-psp.yaml
@@ -18,6 +18,7 @@ spec:
   privileged: {{ .Values.gremlin.podSecurity.privileged }}
   allowPrivilegeEscalation: {{ .Values.gremlin.podSecurity.allowPrivilegeEscalation }}
   readOnlyRootFilesystem: {{ .Values.gremlin.podSecurity.readOnlyRootFilesystem }}
+  dnsPolicy: {{ .Values.gremlin.dnsPolicy }}
   hostNetwork: {{ .Values.gremlin.hostNetwork }}
   hostIPC: false
   hostPID: {{ .Values.gremlin.hostPID }}

--- a/gremlin/tests/daemonset_test.yaml
+++ b/gremlin/tests/daemonset_test.yaml
@@ -2,7 +2,7 @@ suite: test daemonset
 templates:
   - daemonset.yaml
 tests:
-  - it: should create a deployment
+  - it: should create a daemonset
     asserts:
       - isKind:
           of: DaemonSet

--- a/gremlin/tests/notes_test.yaml
+++ b/gremlin/tests/notes_test.yaml
@@ -4,8 +4,10 @@ templates:
 tests:
   - it: should fail if a managed secret is used and no key or certificate is passed
     set:
-      gremlin.secret.managed: true
-      gremlin.secret.type: certificate
+      gremlin:
+        secret:
+          type: certificate
+          managed: true
     asserts:
       - failedTemplate:
           errorPattern: "When using a managed certificate, both the certificate and key must be provided."

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -59,13 +59,22 @@ gremlin:
   #
   hostPID: true
 
+  # gremlin.dnsPolicy -
+  # A Kubernetes DNS policy that determines how the Gremlin Daemonset should resolve DNS queries.
+  #  Possible values are:
+  #   ClusterFirstWithHostNet - The default. This will use the cluster DNS service first, but will also
+  #                             use the host's DNS configuration as a fallback. Use this to resolve
+  #                             hostnames of Kubernetes services defined in the cluster.
+  #   ClusterFirst - Uses only the cluster DNS service.
+  dnsPolicy: ClusterFirstWithHostNet
+
   # gremlin.hostNetwork -
   # This must be true for any Gremlin installation that wishes to carry out network attacks at the host-level. It
   #   is also required for Gremlin's dependency discovery features.
   hostNetwork: true
 
   # gremlin.installApparmorProfile -
-  # This controls if gremlin installs it's own apparmor profile.  This is only necessary if you're running apparmor
+  # This controls if gremlin installs its own apparmor profile.  This is only necessary if you're running apparmor
   installApparmorProfile: false
 
   client:


### PR DESCRIPTION
## Background

Gremlin may need to resolve the hostnames of services defined in a cluster. For example, in order to access linkerd's destination api, our customer would have to patch their cluster with the following after a helm install:

```
kubectl patch daemonset/gremlin -n gremlin --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/dnsPolicy", "value":"ClusterFirstWithHostNet"}]'
```

## Changes

Allow the gremlin daemonset's dns policy to be configurable so the patch is no longer necessary.  Default to `ClusterFirstWithHostNet` instead of `ClusterFirst` to resolve the hostnames of these services.

## Testing

Tested without specifying the dnsPolicy (results in the default `ClusterFirstWithHostNet`):

```
$ helm install gremlin ./gremlin \
  --namespace gremlin \
  --set gremlin.secret.managed=true \
  --set gremlin.secret.type=secret \
  --set gremlin.secret.clusterID=rowe-minikube \
  --set gremlin.secret.teamID=<redacted> \
  --set gremlin.secret.teamSecret=<redacted>
 
NAME: gremlin
LAST DEPLOYED: Mon Apr 14 16:28:37 2025
NAMESPACE: gremlin
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Validation succeeded.

$ kubectl get daemonset gremlin -n gremlin -o 'jsonpath={.spec.template.spec.dnsPolicy}'
ClusterFirstWithHostNet                                                                                                                                                                                                       
```

Explicitly set `ClusterFirstWithHostNet`:
```
$ helm install gremlin ./gremlin \
  --namespace gremlin \
  --set gremlin.secret.managed=true \
  --set gremlin.secret.type=secret \
  --set gremlin.secret.clusterID=rowe-minikube \
  --set gremlin.secret.teamID=<redacted> \
  --set gremlin.secret.teamSecret=<redacted> \
  --set gremlin.dnsPolicy=ClusterFirstWithHostNet
NAME: gremlin
LAST DEPLOYED: Mon Apr 14 16:28:43 2025
NAMESPACE: gremlin
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Validation succeeded.

$ kubectl get daemonset gremlin -n gremlin -o 'jsonpath={.spec.template.spec.dnsPolicy}'
ClusterFirstWithHostNet
```

Explicitly set `ClusterFirst`:
```
$ helm install gremlin ./gremlin \
  --namespace gremlin \
  --set gremlin.secret.managed=true \
  --set gremlin.secret.type=secret \
  --set gremlin.secret.clusterID=rowe-minikube \
  --set gremlin.secret.teamID=<redacted> \
  --set gremlin.secret.teamSecret=<redacted> \
  --set gremlin.dnsPolicy=ClusterFirst
NAME: gremlin
LAST DEPLOYED: Mon Apr 14 16:28:50 2025
NAMESPACE: gremlin
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Validation succeeded.

$ kubectl get daemonset gremlin -n gremlin -o 'jsonpath={.spec.template.spec.dnsPolicy}'
ClusterFirst
```