### PR TITLE
Rename ClusterRoleBinding to gremlin-metadata-reader

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.22.0
+version: 0.22.1
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/gremlin-service-account.yaml
+++ b/gremlin/templates/gremlin-service-account.yaml
@@ -26,7 +26,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gremlin
+  name: gremlin-metadata-reader
 subjects:
   - kind: ServiceAccount
     name: gremlin


### PR DESCRIPTION
## Background

A rename in the cluster role binding was causing problems in upgrading from `0.21.0` to `0.22.0`.


## Changes
Rename the cluster role binding to `gremlin-metadata-reader` from `gremlin`. Thanks to @philgebhardt and @thefirstofthe300 for help in sorting this out.

## Testing

Installed `0.21.0`:

```bash
$ helm -n gremlin list

NAME   	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART         	APP VERSION
gremlin	gremlin  	2       	2025-05-05 14:20:40.110859 -0600 MDT	deployed	gremlin-0.21.0
```

Before (failed to upgrade to `0.22.0`):

```bash
$ helm upgrade gremlin gremlin/gremlin -n gremlin --version 0.22.0

Error: UPGRADE FAILED: cannot patch "gremlin" with kind ClusterRoleBinding: ClusterRoleBinding.rbac.authorization.k8s.io "gremlin" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"ClusterRole", Name:"gremlin-metadata-reader"}: cannot change roleRef
```

After (successfully upgraded to `0.22.1`):
```bash
$ helm upgrade gremlin ../helm/gremlin -n gremlin --version 0.22.1

Release "gremlin" has been upgraded. Happy Helming!
NAME: gremlin
LAST DEPLOYED: Mon May  5 14:22:18 2025
NAMESPACE: gremlin
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
Validation succeeded.
```