### PR TITLE
discoverDestinationService: allow endpointslices for KubeResolver

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.22.2
+version: 0.23.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/gremlin-service-account.yaml
+++ b/gremlin/templates/gremlin-service-account.yaml
@@ -22,6 +22,11 @@ rules:
       - "services"
       {{- end }}
     verbs: ["get"]
+{{- if .Values.gremlin.features.discoverDestinationService.enabled }}
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list","watch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/gremlin/tests/gremlin_service_account_test.yaml
+++ b/gremlin/tests/gremlin_service_account_test.yaml
@@ -36,6 +36,16 @@ tests:
               - services
             verbs:
               - get
+      - equal:
+          path: rules[1]
+          value:
+            apiGroups:
+              - "discovery.k8s.io"
+            resources:
+              - endpointslices
+            verbs:
+              - list
+              - watch
   - it: should not grant permissions to read services if destination service discovery is disabled
     set:
       gremlin.features.discoverDestinationService.enabled: false

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -273,7 +273,10 @@ gremlin:
   features:
 
     # gremlin.features.discoverDestinationService.enabled
-    # Enable discovery of a destination service in a service mesh to resolve hostnames
+    # Give gremlin permissions to discover any supported destination services such has linkerd-dst, and Kubernetes EndpointSlices
+    #   The ClusterRole associated with Gremlin's service account receives the following access
+    #     - Services: get
+    #     - discover.k8s.io/EndpointSlices: watch
     discoverDestinationService:
       enabled: false
 

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -276,7 +276,7 @@ gremlin:
     # Give gremlin permissions to discover any supported destination services such has linkerd-dst, and Kubernetes EndpointSlices
     #   The ClusterRole associated with Gremlin's service account receives the following access
     #     - Services: get
-    #     - discover.k8s.io/EndpointSlices: watch
+    #     - discover.k8s.io/EndpointSlices: watch, list
     discoverDestinationService:
       enabled: false
 


### PR DESCRIPTION
## Background

* An upcoming gremlin release will have the ability to resolve ip-addresses for services by resolving EndpointSlices.
* When `discoverDestinationService` is enabled, we want to provide permissions for this resolver.

## Change

* Apply new permissions for new functionality only when the `discoverDestinationService` is enabled.

## Test

* Add unittest to ensure expected behavior