### PR TITLE
Add autoscaling read permissions

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.22.2
+version: 0.23.0
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/chao-service-account.yaml
+++ b/gremlin/templates/chao-service-account.yaml
@@ -29,7 +29,10 @@ rules:
     verbs: ["get", "watch", "list"]
   - apiGroups: ["argoproj.io"]
     resources: ["rollouts"]
-    verbs: ["get", "list", "watch"]    
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
# Background
* An upcoming gremlin release will have a new detected risk related to HorizontalPodAutoscaler(s)
# Change
* Apply new permission to allow reading information about HorizontalPodAutoscalers