### PR TITLE
Update values.yaml SYS_RESOURCE explanation

### DIFF
--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -135,7 +135,7 @@ gremlin:
       - SYS_BOOT        # Required to run Shutdown attacks
       - SYS_TIME        # Required to run Time Travel attacks
       - DAC_READ_SEARCH # Required to run Certificate Expiry attacks with CIDR address arguments, and to discover dependencies
-      - SYS_RESOURCE    # Required to run Process Exhaustion attacks against containers
+      - SYS_RESOURCE    # Required to run Process Exhaustion and Memory attacks against containers
       - SYS_ADMIN       # Required to apply impact within container namespaces
       - SYS_PTRACE      # Required to to identify charactistics of container processes (such as associated network)
       - NET_RAW         # Required to discover dependencies


### PR DESCRIPTION
In agent 2.59.0, a change was introduced where memory attacks need CAP_SYS_RESOURCE to function. I have updated the associated comments to this effect