### PR TITLE
Upgrade checkout action to v4 and unittest version to v1.1.0

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: d3adb5/helm-unittest-action@v2
         with:
           helm-version: v3.17.0
-          unittest-version: v1.1.0
+          unittest-version: v1.1.1
           install-mode: if-not-present

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: d3adb5/helm-unittest-action@v2
         with:
           helm-version: v3.17.0
-          unittest-version: v1.1.1
+          unittest-version: v1.0.3
           install-mode: if-not-present

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,7 +6,9 @@ jobs:
   unittest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - uses: d3adb5/helm-unittest-action@v2
         with:
           helm-version: v3.17.0
+          unittest-version: v1.1.0

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           helm-version: v3.17.0
           unittest-version: v1.1.0
+          install-mode: if-not-present


### PR DESCRIPTION
attempt to fix broken helm unit tests GHA which is failing

The actual Helm/plugin error is being hidden because stdout/stderr are redirected to /dev/null