### PR TITLE
[Resources] Make chao resources configurable via chao.resources

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.25.3
+version: 0.25.4
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -31,6 +31,7 @@ their default values. See values.yaml for all available options.
 | `chao.tolerations`                     | List of node taints to tolerate for the `chao` container       | `[]`                                                                                        |
 | `chao.affinity`                        | Map of node/pod affinities for the `chao` container            | `{}`                                                                                        |
 | `chao.create`                          | Enable kubernetes targeting by installing k8s client           | true                                                                                        |
+| `chao.resources`                       | Set resource requests and limits for the chao deployment       | `{}`                                                                                        |
 | `chao.extraEnv`                        | Specify any arbitrary environment variables to pass to the Chao deployment. | `[]`                                                                                        |
 | `chao.namespaces`                      | List of namespaces for Gremlin to watch for attacking          | `[]`                                                                                        
 | `gremlin.podLabels`           | Kubernetes labels applied to the Gremlin Agent's DaemonSet and it's pods| `{}`                                                                                        |

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -54,9 +54,9 @@ spec:
       {{- end }}
       containers:
         - image: {{ .Values.chaoimage.repository }}:{{ .Values.chaoimage.tag }}
-        {{- if .Values.resources }}
+        {{- with (default .Values.resources .Values.chao.resources) }}
           resources:
-{{ toYaml .Values.resources | trimSuffix "\n" | indent 12 }}
+{{ toYaml . | trimSuffix "\n" | indent 12 }}
         {{- end }}
           securityContext:
             readOnlyRootFilesystem: true

--- a/gremlin/tests/chao_deployment_resources_test.yaml
+++ b/gremlin/tests/chao_deployment_resources_test.yaml
@@ -1,0 +1,55 @@
+suite: Test Chao deployment resources
+templates:
+  - chao-deployment.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  upgrade: true
+
+tests:
+  - it: should render resources when chao.resources is set
+    set:
+      chao.resources.limits.cpu: "100m"
+      chao.resources.limits.memory: "64Mi"
+      chao.resources.requests.cpu: "10m"
+      chao.resources.requests.memory: "32Mi"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "100m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "64Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "10m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "32Mi"
+
+  - it: should honor the top-level resources block for backwards compatibility
+    set:
+      resources.limits.cpu: "200m"
+      resources.requests.cpu: "50m"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "200m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "50m"
+
+  - it: should prefer chao.resources over the top-level resources block
+    set:
+      resources.limits.cpu: "200m"
+      chao.resources.limits.cpu: "100m"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "100m"
+
+  - it: should not render a resources block when neither is set
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources

--- a/gremlin/tests/daemonset_resources_test.yaml
+++ b/gremlin/tests/daemonset_resources_test.yaml
@@ -1,0 +1,34 @@
+suite: Test daemonset resources
+templates:
+  - daemonset.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+  revision: 1
+  upgrade: true
+
+tests:
+  - it: should render resources when gremlin.resources is set
+    set:
+      gremlin.resources.limits.cpu: "500m"
+      gremlin.resources.limits.memory: "256Mi"
+      gremlin.resources.requests.cpu: "100m"
+      gremlin.resources.requests.memory: "32Mi"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "500m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "256Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "100m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "32Mi"
+
+  - it: should not render a resources block when gremlin.resources is unset
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -354,6 +354,14 @@ chao:
   #   targeting for Gremlin attacks
   create: true
 
+  # chao.resources -
+  # Set resource requests and limits for the Chao deployment.
+  # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
+  #
+  # NOTE: For backwards compatibility, a top-level `resources` block is still honored when `chao.resources`
+  # is unset, but `chao.resources` is preferred and takes precedence.
+  resources: {}
+
   # chao.updateStrategy -
   # The rollout strategy Kubernetes will use when updating the Chao deployment
   updateStrategy:


### PR DESCRIPTION
 chao deployment reads a top-level  key while every other workload namespaces resources under its own block
 (gremlin.resources).
 
 chao.resources was silently ignored.

chao-deployment.yaml now reads chao.resources, falling back to the top-level  resources block so existing users are not 
broken. 

Documents chao.resources in values.yaml and the README, and adds unit tests covering chao resources
 (set, fallback, precedence, absence) plus previously-uncovered daemonset gremlin.resources rendering