### PR TITLE
chao: grant access to policy/poddisruptionbudgets

### DIFF
--- a/gremlin/Chart.yaml
+++ b/gremlin/Chart.yaml
@@ -1,5 +1,5 @@
 name: gremlin
-version: 0.25.3
+version: 0.25.4
 description: The Gremlin Inc client application
 apiVersion: v1
 home: https://www.gremlin.com

--- a/gremlin/templates/chao-service-account.yaml
+++ b/gremlin/templates/chao-service-account.yaml
@@ -33,6 +33,9 @@ rules:
   - apiGroups: ["autoscaling"]
     resources: ["horizontalpodautoscalers"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## chao: grant access to policy/poddisruptionbudgets

Adds list/watch on `policy/v1.PodDisruptionBudget` to the `gremlin-watcher` ClusterRole. Pairs with the `deploy/chao.yml` change in [gremlin/chao#331](https://github.com/gremlin/chao/pull/331).

### Why

Chao now watches PodDisruptionBudgets so the service-side detected-risk engine can evaluate `Kubernetes PodDisruptionBudget Missing` (EN-10918). Without the matching RBAC rule on the customer's cluster, chao's startup probe fails on `policy/v1.poddisruptionbudgets`, the agent emits the `DD009` error code and skips the PDB informer, and the risk silently has no data to evaluate against.

### What changes

- `gremlin/templates/chao-service-account.yaml` — adds the rule, matching the pattern of existing access-gated resources like `autoscaling/horizontalpodautoscalers` and `networking.k8s.io/ingresses`.
- `gremlin/Chart.yaml` — bumps chart version 0.25.3 → 0.25.4 to reflect the changed RBAC surface.

### Risk

Low. Additive RBAC change; doesn't remove or modify existing permissions. Clusters