### PR TITLE
Add dynamic k8s query feature

### DIFF
--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -108,7 +108,7 @@ _note_: Depending on your shell you may need different quoting around `toleratio
 
 By default, Chao reads a fixed set of Kubernetes resources — the ones named in the `gremlin-watcher` ClusterRole. Enabling `chao.features.dynamicQuery` lets Gremlin query resources beyond that set. `allowlist` says which ones: each entry maps directly onto an RBAC rule and accepts `apiGroups`, `resources`, and an optional `verbs`, and is added to the `gremlin-watcher` ClusterRole. Every entry has to name its `apiGroups` and `resources` — nothing is wildcarded on your behalf, and an entry that leaves `apiGroups` out fails the install rather than being granted across every API group.
 
-**The allowlist is the whole boundary, and it lives only in RBAC.** Chao is told the feature is on (the `-dynamic_query` flag) but is never handed the list of resources — it discovers what it may read by being refused, and handles the `403` itself. Anything absent from the allowlist is refused by the API server, so there is nothing Chao has to be trusted to honor. Kubernetes RBAC has no deny rule, so the grant is the only place a limit can be expressed.
+**RBAC is the boundary, and Chao holds a denylist inside it.** Chao is told the feature is on (the `-dynamic_query` flag) but is never handed the allowlist — it discovers what it may read by being refused, and handles the `403` itself. Anything absent from the allowlist is refused by the API server, so the outer limit is not something Chao has to be trusted to honor. Kubernetes RBAC has no deny rule, so a grant is the only place that outer limit can be expressed; `denylist` is the inner one, enforced by Chao, for carving resources back out of a grant that is broader than you want. It is passed as `-deny_resources` and adds to a built-in denylist that always applies and cannot be turned off.
 
 Dynamic queries are **read-only**. `verbs` defaults to `get` and `list` and may narrow to a subset of those two; any other verb — including `watch` and the `"*"` wildcard — fails the install. Chao cannot watch these resources, so it polls them. The base `gremlin-watcher` rules are unaffected and keep their `watch`.
 
@@ -120,7 +120,7 @@ Some things are deliberately left out of it:
 
 | Left out of the default | Why |
 | --- | --- |
-| `secrets`, `configmaps` | ConfigMaps are included because connection strings, tokens, and API keys are commonly stored in them |
+| `secrets`, `configmaps` | Both commonly hold connection strings, tokens, and API keys |
 | `pods/log` | Application logs commonly contain tokens and personal data |
 | `nodes/proxy` | Reaches the kubelet API, exposing every pod spec — and its environment — on a node |
 | `services/proxy` | An HTTP tunnel into any in-cluster service, bypassing NetworkPolicy |
@@ -148,6 +148,27 @@ chao:
 ```
 
 which grants Chao read access to `pods`, `services`, and Argo CD `applications`, plus `get` on `deployments`. Enabling the feature with an allowlist that names no resources fails the install rather than silently deploying a Chao that cannot query anything.
+
+### Denying resources inside the allowlist
+
+`denylist` names resources Chao may never read, as `resource.group` or `*.group`:
+
+```yaml
+chao:
+  features:
+    dynamicQuery:
+      enabled: true
+      allowlist:
+        - apiGroups: ["example.com"]
+          resources: ["*"]
+      denylist:
+        - "credentials.example.com"
+        - "*.vault.example.com"
+```
+
+which grants Chao every resource in `example.com` except `credentials`, and denies the `vault.example.com` group outright. Entries are joined into one `-deny_resources` flag, so each has to be a single name with no commas or spaces. Use the empty group for core resources — `secrets.` rather than `secrets`.
+
+Reach for this when an allowlist entry is broader than you want — a wildcard over a custom API group, say — and RBAC would need the grant enumerated resource by resource to express the same thing. It adds to Chao's built-in denylist, which always applies. Denying something the allowlist never granted is harmless but redundant: RBAC already refuses it.
 
 ## Installation
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -34,6 +34,8 @@ their default values. See values.yaml for all available options.
 | `chao.resources`                       | Set resource requests and limits for the chao deployment       | `{}`                                                                                        |
 | `chao.extraEnv`                        | Specify any arbitrary environment variables to pass to the Chao deployment. | `[]`                                                                                        |
 | `chao.namespaces`                      | List of namespaces for Gremlin to watch for attacking          | `[]`                                                                                        
+| `chao.features.dynamicQuery.enabled`   | Let Gremlin query Kubernetes resources beyond the fixed set Chao watches by default. [See below](#chao-dynamic-queries) | `false`                                                       |
+| `chao.features.dynamicQuery.allowlist` | RBAC rules describing the resources Chao may query. [See below](#chao-dynamic-queries) | The resources describing a cluster's shape, scheduling, and health (see values.yaml)        |
 | `gremlin.podLabels`           | Kubernetes labels applied to the Gremlin Agent's DaemonSet and it's pods| `{}`                                                                                        |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                                        |
 | `gremlin.installApparmorProfile`       | Have Gremlin install their own [Apparmor Profile](agent_apparmor.profile) (NOTE: `gremlin.apparmor` overrides this) | `false`                                                                                     |
@@ -101,6 +103,51 @@ $ helm install gremlin gremlin/gremlin \
   --set       'tolerations[0].operator=Exists'
 ```
 _note_: Depending on your shell you may need different quoting around `tolerations[0]`
+
+## Chao dynamic queries
+
+By default, Chao reads a fixed set of Kubernetes resources — the ones named in the `gremlin-watcher` ClusterRole. Enabling `chao.features.dynamicQuery` lets Gremlin query resources beyond that set. `allowlist` says which ones: each entry maps directly onto an RBAC rule and accepts `apiGroups`, `resources`, and an optional `verbs`, and is added to the `gremlin-watcher` ClusterRole. Every entry has to name its `apiGroups` and `resources` — nothing is wildcarded on your behalf, and an entry that leaves `apiGroups` out fails the install rather than being granted across every API group.
+
+**The allowlist is the whole boundary, and it lives only in RBAC.** Chao is told the feature is on (the `-dynamic_query` flag) but is never handed the list of resources — it discovers what it may read by being refused, and handles the `403` itself. Anything absent from the allowlist is refused by the API server, so there is nothing Chao has to be trusted to honor. Kubernetes RBAC has no deny rule, so the grant is the only place a limit can be expressed.
+
+Dynamic queries are **read-only**. `verbs` defaults to `get` and `list` and may narrow to a subset of those two; any other verb — including `watch` and the `"*"` wildcard — fails the install. Chao cannot watch these resources, so it polls them. The base `gremlin-watcher` rules are unaffected and keep their `watch`.
+
+### What the default grants
+
+The default covers the resources that describe a cluster's shape, scheduling, and health — `endpoints`, `events`, `persistentvolumeclaims`, `jobs`, `networkpolicies`, `storageclasses`, `customresourcedefinitions`, and the like — on top of the workloads the base `gremlin-watcher` rules already watch. See [values.yaml](values.yaml) for the full list.
+
+Some things are deliberately left out of it:
+
+| Left out of the default | Why |
+| --- | --- |
+| `secrets`, `configmaps` | ConfigMaps are included because connection strings, tokens, and API keys are commonly stored in them |
+| `pods/log` | Application logs commonly contain tokens and personal data |
+| `nodes/proxy` | Reaches the kubelet API, exposing every pod spec — and its environment — on a node |
+| `services/proxy` | An HTTP tunnel into any in-cluster service, bypassing NetworkPolicy |
+| RBAC roles and bindings | A map of which identity is allowed to do what, which is reconnaissance for privilege escalation |
+
+Note that an RBAC `resources: ["*"]` wildcard matches subresources as well as resources, so a wildcard entry reaches `pods/log` and the proxy subresources too.
+
+### Changing what Chao can reach
+
+Setting `allowlist` replaces the default outright, so name every resource Gremlin should reach:
+
+```yaml
+chao:
+  features:
+    dynamicQuery:
+      enabled: true
+      allowlist:
+        - apiGroups: [""]
+          resources: ["pods", "services"]
+        - apiGroups: ["apps"]
+          resources: ["deployments"]
+          verbs: ["get"]
+        - apiGroups: ["argoproj.io"]
+          resources: ["applications"]
+```
+
+which grants Chao read access to `pods`, `services`, and Argo CD `applications`, plus `get` on `deployments`. Enabling the feature with an allowlist that names no resources fails the install rather than silently deploying a Chao that cannot query anything.
 
 ## Installation
 

--- a/gremlin/templates/_validation.tpl
+++ b/gremlin/templates/_validation.tpl
@@ -6,6 +6,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "gremlin.validateValues.secret" .) -}}
 {{- $messages := append $messages (include "gremlin.validateValues.chaoDynamicQuery" .) -}}
 {{- $messages := append $messages (include "gremlin.validateValues.chaoDynamicQueryVerbs" .) -}}
+{{- $messages := append $messages (include "gremlin.validateValues.chaoDynamicQueryDenylist" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -41,8 +42,9 @@ Compile all warnings into a single message, and call fail.
 
 {{/*
 The allowlist is the whole of what chao may read, so it has to say so exactly. An entry that omits its apiGroups is
-rejected rather than defaulted to every group, and an enabled feature naming no resources at all is rejected rather
-than deploying a chao that cannot query anything.
+rejected rather than defaulted to every group, an entry that omits its resources is rejected rather than rendered as
+a rule granting nothing, and an enabled feature naming no resources at all is rejected rather than deploying a chao
+that cannot query anything.
 */}}
 {{- define "gremlin.validateValues.chaoDynamicQuery" -}}
 {{- if .Values.chao.features.dynamicQuery.enabled -}}
@@ -50,6 +52,9 @@ than deploying a chao that cannot query anything.
 {{- $resources := list -}}
 {{- range $entry := default (list) .Values.chao.features.dynamicQuery.allowlist -}}
 {{- $resources = concat $resources (default (list) $entry.resources) -}}
+{{- if not $entry.resources -}}
+{{- $errors = append $errors (printf "- chao.features.dynamicQuery.allowlist entry for apiGroups %s does not name its resources. Name them explicitly." (toJson (default (list) $entry.apiGroups))) -}}
+{{- end -}}
 {{- if not $entry.apiGroups -}}
 {{- $errors = append $errors (printf "- chao.features.dynamicQuery.allowlist entry for resources %s does not name its apiGroups. Name them explicitly; the core API group is the empty string (\"\")." (toJson (default (list) $entry.resources))) -}}
 {{- end -}}
@@ -58,5 +63,24 @@ than deploying a chao that cannot query anything.
 {{- $errors = append $errors "- chao.features.dynamicQuery is enabled but its allowlist names no resources. List the resources Gremlin should be able to query, or disable the feature." -}}
 {{- end -}}
 {{- join "\n" (uniq $errors) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The denylist is joined into a single comma-separated -deny_resources flag, so an entry carrying its own comma or a
+stray space would silently become something other than what was written.
+*/}}
+{{- define "gremlin.validateValues.chaoDynamicQueryDenylist" -}}
+{{- if .Values.chao.features.dynamicQuery.enabled -}}
+{{- $rejected := list -}}
+{{- range $entry := default (list) .Values.chao.features.dynamicQuery.denylist -}}
+{{- $entry = toString $entry -}}
+{{- if or (eq $entry "") (contains "," $entry) (ne $entry (nospace $entry)) -}}
+{{- $rejected = append $rejected (toJson $entry) -}}
+{{- end -}}
+{{- end -}}
+{{- if $rejected -}}
+- chao.features.dynamicQuery.denylist entries are joined into one -deny_resources flag, so each must name a single resource as resource.group or *.group, with no commas or spaces. Found: {{ join ", " (uniq $rejected) }}.
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/gremlin/templates/_validation.tpl
+++ b/gremlin/templates/_validation.tpl
@@ -4,6 +4,8 @@ Compile all warnings into a single message, and call fail.
 {{- define "gremlin.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := append $messages (include "gremlin.validateValues.secret" .) -}}
+{{- $messages := append $messages (include "gremlin.validateValues.chaoDynamicQuery" .) -}}
+{{- $messages := append $messages (include "gremlin.validateValues.chaoDynamicQueryVerbs" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -17,5 +19,44 @@ Compile all warnings into a single message, and call fail.
 {{- define "gremlin.validateValues.secret" -}}
 {{- if and .Values.gremlin.secret.managed (eq .Values.gremlin.secret.type "certificate") (or (not .Values.gremlin.secret.certificate) (not .Values.gremlin.secret.key)) -}}
 - When using a managed certificate, both the certificate and key must be provided.
+{{- end -}}
+{{- end -}}
+
+{{- define "gremlin.validateValues.chaoDynamicQueryVerbs" -}}
+{{- if .Values.chao.features.dynamicQuery.enabled -}}
+{{- $readOnly := list "get" "list" -}}
+{{- $rejected := list -}}
+{{- range $entry := default (list) .Values.chao.features.dynamicQuery.allowlist -}}
+{{- range $verb := default (list) $entry.verbs -}}
+{{- if not (has $verb $readOnly) -}}
+{{- $rejected = append $rejected $verb -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $rejected -}}
+- chao.features.dynamicQuery.allowlist grants only the read-only verbs get and list, but found: {{ join ", " (uniq $rejected) }}.
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The allowlist is the whole of what chao may read, so it has to say so exactly. An entry that omits its apiGroups is
+rejected rather than defaulted to every group, and an enabled feature naming no resources at all is rejected rather
+than deploying a chao that cannot query anything.
+*/}}
+{{- define "gremlin.validateValues.chaoDynamicQuery" -}}
+{{- if .Values.chao.features.dynamicQuery.enabled -}}
+{{- $errors := list -}}
+{{- $resources := list -}}
+{{- range $entry := default (list) .Values.chao.features.dynamicQuery.allowlist -}}
+{{- $resources = concat $resources (default (list) $entry.resources) -}}
+{{- if not $entry.apiGroups -}}
+{{- $errors = append $errors (printf "- chao.features.dynamicQuery.allowlist entry for resources %s does not name its apiGroups. Name them explicitly; the core API group is the empty string (\"\")." (toJson (default (list) $entry.resources))) -}}
+{{- end -}}
+{{- end -}}
+{{- if not $resources -}}
+{{- $errors = append $errors "- chao.features.dynamicQuery is enabled but its allowlist names no resources. List the resources Gremlin should be able to query, or disable the feature." -}}
+{{- end -}}
+{{- join "\n" (uniq $errors) -}}
 {{- end -}}
 {{- end -}}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -130,6 +130,10 @@ spec:
             {{- end}}
             {{- if .Values.chao.features.dynamicQuery.enabled }}
             - "-dynamic_query"
+            {{- with .Values.chao.features.dynamicQuery.denylist }}
+            - "-deny_resources"
+            - "{{ join "," . }}"
+            {{- end }}
             {{- end }}
             {{- if include "chaoTlsIdentityArgs" . }}
             {{- include "chaoTlsIdentityArgs" . | nindent 12 }}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -128,6 +128,9 @@ spec:
             - "-namespaces"
             - "{{ join "," .Values.chao.namespaces }}"
             {{- end}}
+            {{- if .Values.chao.features.dynamicQuery.enabled }}
+            - "-dynamic_query"
+            {{- end }}
             {{- if include "chaoTlsIdentityArgs" . }}
             {{- include "chaoTlsIdentityArgs" . | nindent 12 }}
             {{- end }}

--- a/gremlin/templates/chao-service-account.yaml
+++ b/gremlin/templates/chao-service-account.yaml
@@ -36,6 +36,13 @@ rules:
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "watch", "list"]
+{{- if .Values.chao.features.dynamicQuery.enabled }}
+{{- range .Values.chao.features.dynamicQuery.allowlist }}
+  - apiGroups: {{ toJson .apiGroups }}
+    resources: {{ toJson .resources }}
+    verbs: {{ toJson (default (list "get" "list") .verbs) }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/gremlin/tests/notes_test.yaml
+++ b/gremlin/tests/notes_test.yaml
@@ -11,3 +11,61 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "When using a managed certificate, both the certificate and key must be provided."
+  - it: should fail if dynamic query is enabled but its allowlist is empty
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            allowlist: []
+    asserts:
+      - failedTemplate:
+          errorPattern: "chao.features.dynamicQuery is enabled but its allowlist names no resources"
+  - it: should fail if dynamic query is enabled but no allowlist entry names a resource
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            allowlist:
+              - apiGroups: ["apps"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "chao.features.dynamicQuery is enabled but its allowlist names no resources"
+  - it: should fail if a dynamic query allowlist entry does not name its apiGroups
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            allowlist:
+              - resources: ["deployments"]
+    asserts:
+      - failedTemplate:
+          errorPattern: 'entry for resources \["deployments"\] does not name its apiGroups'
+  - it: should fail if a dynamic query allowlist entry asks for a verb other than get or list
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            allowlist:
+              - apiGroups: ["apps"]
+                resources: ["deployments"]
+                verbs: ["get", "watch", "list"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "grants only the read-only verbs get and list, but found: watch"
+  - it: should fail if a dynamic query allowlist entry asks for the verb wildcard
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            allowlist:
+              - apiGroups: ["*"]
+                resources: ["*"]
+                verbs: ["*"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "grants only the read-only verbs get and list"

--- a/gremlin/tests/notes_test.yaml
+++ b/gremlin/tests/notes_test.yaml
@@ -32,6 +32,19 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "chao.features.dynamicQuery is enabled but its allowlist names no resources"
+  - it: should fail if a dynamic query allowlist entry does not name its resources
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            allowlist:
+              - apiGroups: [""]
+                resources: ["pods"]
+              - apiGroups: ["apps"]
+    asserts:
+      - failedTemplate:
+          errorPattern: 'entry for apiGroups \["apps"\] does not name its resources'
   - it: should fail if a dynamic query allowlist entry does not name its apiGroups
     set:
       chao:
@@ -69,3 +82,42 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "grants only the read-only verbs get and list"
+  - it: should fail if a dynamic query denylist entry contains a comma
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            denylist: ["secrets.,configmaps."]
+    asserts:
+      - failedTemplate:
+          errorPattern: "denylist entries are joined into one -deny_resources flag"
+  - it: should fail if a dynamic query denylist entry contains a space
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            denylist: ["secrets. configmaps."]
+    asserts:
+      - failedTemplate:
+          errorPattern: 'Found: "secrets\. configmaps\."'
+  - it: should fail if a dynamic query denylist entry is empty
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            denylist: ["secrets.", ""]
+    asserts:
+      - failedTemplate:
+          errorPattern: "denylist entries are joined into one -deny_resources flag"
+  - it: should accept a well-formed dynamic query denylist
+    set:
+      chao:
+        features:
+          dynamicQuery:
+            enabled: true
+            denylist: ["secrets.", "credentials.example.com", "*.vault.example.com"]
+    asserts:
+      - notFailedTemplate: {}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -537,11 +537,12 @@ chao:
       # chao.features.dynamicQuery.allowlist
       # The Kubernetes resources Chao is allowed to query. Each entry maps directly onto an RBAC rule and accepts
       #   `apiGroups`, `resources`, and an optional `verbs`. Both `apiGroups` and `resources` must be named — there
-      #   is no wildcard default, and an entry that omits its `apiGroups` fails the install rather than being
-      #   granted across every group. The core API group is the empty string (`""`).
+      #   is no wildcard default. An entry that omits its `apiGroups` fails the install rather than being granted
+      #   across every group, and an entry that omits its `resources` fails rather than rendering a rule that grants
+      #   nothing. The core API group is the empty string (`""`).
       #
-      # This list is the whole of what Gremlin can read, and the only place that limit exists: anything absent from
-      #   it is refused by the API server, not by Chao.
+      # This list is the outer bound of what Gremlin can read: anything absent from it is refused by the API server,
+      #   not by Chao. `denylist` below narrows it further from inside Chao.
       #
       # The default covers the resources that describe a cluster's shape, scheduling, and health, on top of the
       #   workloads the base `gremlin-watcher` rules already watch. Setting this replaces the default outright, so
@@ -576,6 +577,17 @@ chao:
           resources: ["pods", "nodes"]
         - apiGroups: ["apiextensions.k8s.io"]
           resources: ["customresourcedefinitions"]
+
+      # chao.features.dynamicQuery.denylist
+      # Resources object queries may never read, named as `resource.group` or `*.group` — for example
+      #   `secrets.` for core Secrets, `secrets.example.com` for a custom resource, or `*.example.com` for every
+      #   resource in a group. Passed to Chao as `-deny_resources` and enforced by Chao itself.
+      #
+      # This adds to Chao's built-in denylist, which always applies and cannot be turned off. Use it to carve out
+      #   resources an allowlist entry would otherwise reach — a broad grant on a custom API group, say, with a
+      #   few of its resources held back. Denying a resource that is not granted in the first place is harmless
+      #   but redundant; RBAC is what actually stops Chao from reading anything absent from `allowlist`.
+      denylist: []
 
 
   # chao.tls -

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -524,6 +524,59 @@ chao:
   # list of namespaces for Gremlin to watch for attacking
   namespaces: []
 
+  # chao.features
+  features:
+
+    # chao.features.dynamicQuery.enabled
+    # Lets Gremlin query Kubernetes resources beyond the fixed set Chao watches by default. When enabled, the
+    #   ClusterRole bound to Chao's service account is extended with the read-only rules
+    #   described by `allowlist`, and Chao is told the feature is on.
+    dynamicQuery:
+      enabled: false
+
+      # chao.features.dynamicQuery.allowlist
+      # The Kubernetes resources Chao is allowed to query. Each entry maps directly onto an RBAC rule and accepts
+      #   `apiGroups`, `resources`, and an optional `verbs`. Both `apiGroups` and `resources` must be named — there
+      #   is no wildcard default, and an entry that omits its `apiGroups` fails the install rather than being
+      #   granted across every group. The core API group is the empty string (`""`).
+      #
+      # This list is the whole of what Gremlin can read, and the only place that limit exists: anything absent from
+      #   it is refused by the API server, not by Chao.
+      #
+      # The default covers the resources that describe a cluster's shape, scheduling, and health, on top of the
+      #   workloads the base `gremlin-watcher` rules already watch. Setting this replaces the default outright, so
+      #   list every resource Gremlin should reach — including any custom resource of your own.
+      #
+      # NOTE: dynamic queries are read-only. `verbs` defaults to `get` and `list`, and may narrow to a subset of
+      #   those two; any other verb (including `watch` and the `"*"` wildcard) fails the install. Chao therefore
+      #   cannot maintain a watch over these resources and must poll them.
+      allowlist:
+        # How workloads are wired together, what they consume, and what has happened to them.
+        - apiGroups: [""]
+          resources: ["endpoints", "events", "limitranges", "persistentvolumeclaims", "persistentvolumes", "resourcequotas"]
+        - apiGroups: ["apps"]
+          resources: ["controllerrevisions"]
+        - apiGroups: ["batch"]
+          resources: ["jobs", "cronjobs"]
+        - apiGroups: ["discovery.k8s.io"]
+          resources: ["endpointslices"]
+        - apiGroups: ["networking.k8s.io"]
+          resources: ["networkpolicies", "ingressclasses"]
+        # Cluster configuration that decides where and how a workload runs.
+        - apiGroups: ["storage.k8s.io"]
+          resources: ["storageclasses", "csidrivers", "csinodes", "volumeattachments"]
+        - apiGroups: ["scheduling.k8s.io"]
+          resources: ["priorityclasses"]
+        - apiGroups: ["node.k8s.io"]
+          resources: ["runtimeclasses"]
+        - apiGroups: ["coordination.k8s.io"]
+          resources: ["leases"]
+        # Live resource usage, and the definitions of whatever custom resources the cluster has installed.
+        - apiGroups: ["metrics.k8s.io"]
+          resources: ["pods", "nodes"]
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources: ["customresourcedefinitions"]
+
 
   # chao.tls -
   # A collection of TLS configurations specific to the Chao Deployment.


### PR DESCRIPTION
For the upcoming Dynamic K8s Query feature, add an option to enable it, and it's expanded set of read capabilities.

K8s doesn't have a deny list, only adding allows, so we're just adding some more basic constructs to the list instead of a wildcard by default.